### PR TITLE
Fixed link to test file for more examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ this.influxDB.write(dbName, TimeUnit.MILLISECONDS, serie1, serie2);
 ```
 
 
-For additional usage examples have a look at [InfluxDBTest.java](https://github.com/majst01/influxdb-java/blob/master/src/test/java/org/influxdb/InfluxDBTest.java "InfluxDBTest.java")
+For additional usage examples have a look at [InfluxDBTest.java](https://github.com/influxdb/influxdb-java/blob/master/src/test/java/org/influxdb/InfluxDBTest.java "InfluxDBTest.java")
 
 ### Build Requirements
 


### PR DESCRIPTION
The old link for additional usage examples (https://github.com/majst01/influxdb-java/blob/master/src/test/java/org/influxdb/InfluxDBTest.java) led to a 404. Updated the link to point to the correct location.
