### PR TITLE
allow user to provide ThreadFactory for BatchProcessor

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -1,6 +1,7 @@
 package org.influxdb;
 
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdb.dto.BatchPoints;
@@ -88,6 +89,21 @@ public interface InfluxDB {
 	 * @return the InfluxDB instance to be able to use it in a fluent manner.
 	 */
 	public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
+
+	/**
+	 * Enable Batching of single Point writes to speed up writes significant. If either actions or
+	 * flushDurations is reached first, a batchwrite is issued.
+	 *
+	 * @param actions
+	 *            the number of actions to collect
+	 * @param flushDuration
+	 *            the time to wait at most.
+	 * @param flushDurationTimeUnit
+	 * @param threadFactory
+	 * 			  the scheduler use the thread factory to generate threads
+	 * @return the InfluxDB instance to be able to use it in a fluent manner.
+	 */
+	public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory);
 
 	/**
 	 * Disable Batching.

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -3,12 +3,9 @@ package org.influxdb.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
@@ -25,7 +22,7 @@ import com.google.common.collect.Maps;
  */
 public class BatchProcessor {
 	protected final BlockingQueue<BatchEntry> queue = new LinkedBlockingQueue<>();
-	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+	private ScheduledExecutorService scheduler;
 	final InfluxDBImpl influxDB;
 	final int actions;
 	private final TimeUnit flushIntervalUnit;
@@ -39,6 +36,7 @@ public class BatchProcessor {
 		private int actions;
 		private TimeUnit flushIntervalUnit;
 		private int flushInterval;
+		private ThreadFactory threadFactory;
 
 		/**
 		 * @param influxDB
@@ -77,6 +75,19 @@ public class BatchProcessor {
 		}
 
 		/**
+		 * The interval at which at least should issued a write.
+		 *
+		 * @param threadFactory
+		 *            the scheduler use the thread factory to generate threads
+		 *
+		 * @return this Builder to use it fluent
+		 */
+		public Builder threadFactory(final ThreadFactory threadFactory) {
+			this.threadFactory = threadFactory;
+			return this;
+		}
+
+		/**
 		 * Create the BatchProcessor.
 		 *
 		 * @return the BatchProcessor instance.
@@ -85,7 +96,7 @@ public class BatchProcessor {
 			Preconditions.checkNotNull(this.actions, "actions may not be null");
 			Preconditions.checkNotNull(this.flushInterval, "flushInterval may not be null");
 			Preconditions.checkNotNull(this.flushIntervalUnit, "flushIntervalUnit may not be null");
-			return new BatchProcessor(this.influxDB, this.actions, this.flushIntervalUnit, this.flushInterval);
+			return new BatchProcessor(this.influxDB, this.actions, this.flushIntervalUnit, this.flushInterval, this.threadFactory);
 		}
 	}
 
@@ -126,12 +137,15 @@ public class BatchProcessor {
 	}
 
 	BatchProcessor(final InfluxDBImpl influxDB, final int actions, final TimeUnit flushIntervalUnit,
-			final int flushInterval) {
+			final int flushInterval, final ThreadFactory threadFactory) {
 		super();
 		this.influxDB = influxDB;
 		this.actions = actions;
 		this.flushIntervalUnit = flushIntervalUnit;
 		this.flushInterval = flushInterval;
+
+		ScheduledThreadPoolExecutor service= (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1, threadFactory);
+		this.scheduler = MoreExecutors.getExitingScheduledExecutorService(service);
 
 		// Flush at specified Rate
 		this.scheduler.scheduleAtFixedRate(new Runnable() {
@@ -140,7 +154,6 @@ public class BatchProcessor {
 				write();
 			}
 		}, this.flushInterval, this.flushInterval, this.flushIntervalUnit);
-
 	}
 
 	void write() {

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -3,7 +3,13 @@ package org.influxdb.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import org.influxdb.InfluxDB;

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -1,6 +1,8 @@
 package org.influxdb.impl;
 
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -41,6 +43,7 @@ public class InfluxDBImpl implements InfluxDB {
 	private final AtomicLong unBatchedCount = new AtomicLong();
 	private final AtomicLong batchedCount = new AtomicLong();
 	private LogLevel logLevel = LogLevel.NONE;
+
 
 	/**
 	 * Constructor which should only be used from the InfluxDBFactory.
@@ -89,6 +92,10 @@ public class InfluxDBImpl implements InfluxDB {
 
 	@Override
 	public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit) {
+		return enableBatch(actions, flushDuration, flushDurationTimeUnit, Executors.defaultThreadFactory());
+	}
+
+	@Override public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory) {
 		if (this.batchEnabled.get()) {
 			throw new IllegalArgumentException("BatchProcessing is already enabled.");
 		}
@@ -96,6 +103,7 @@ public class InfluxDBImpl implements InfluxDB {
 				.builder(this)
 				.actions(actions)
 				.interval(flushDuration, flushDurationTimeUnit)
+				.threadFactory(threadFactory)
 				.build();
 		this.batchEnabled.set(true);
 		return this;


### PR DESCRIPTION
I'm implementing a JVM profiling tool, and I use InfluxDB to store the profiling data.
In my application, I do not want InfluxDB Client to allocate it's own thread.
So an addition argument (ThreadFactory) is added.
