### PR TITLE
Put should always be async

### DIFF
--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -176,12 +176,12 @@ public class BatchProcessor {
 	void put(final BatchEntry batchEntry) {
 		this.queue.add(batchEntry);
 		if (this.queue.size() >= this.actions) {
-		    this.scheduler.submit(new Runnable() {
-                @Override
-                public void run() {
-                    write();
-                }
-		    });
+			this.scheduler.submit(new Runnable() {
+				@Override
+				public void run() {
+					write();
+				}
+			});
 		}
 	}
 

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -176,7 +176,12 @@ public class BatchProcessor {
 	void put(final BatchEntry batchEntry) {
 		this.queue.add(batchEntry);
 		if (this.queue.size() >= this.actions) {
-			write();
+		    this.scheduler.submit(new Runnable() {
+                @Override
+                public void run() {
+                    write();
+                }
+		    });
 		}
 	}
 


### PR DESCRIPTION
When using the batching functionality users do not expect the write method to be synchronous.
