### PR TITLE
Allow non-localhost InfluxDB to be used in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Then you can build influxdb-java with all tests with:
 If you don't have Docker running locally, you can skip tests with -DskipTests flag set to true:
 
     $ mvn clean install -DskipTests=true
+    
+If you have Docker running, but it is not at localhost (e.g. you are on a Mac and using `docker-machine`) you can set an optional environment variable `INFLUXDB_IP` to point to the correct IP address:
+
+    $ export INFLUXDB_IP=192.168.99.100
+    $ mvn test
 
 
 

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -74,8 +74,7 @@ public class InfluxDBTest {
 		// .exec();
 
 		// String ip = inspectContainerResponse.getNetworkSettings().getIpAddress();
-		String ip = "127.0.0.1";
-		this.influxDB = InfluxDBFactory.connect("http://" + ip + ":8086", "root", "root");
+		this.influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":8086", "root", "root");
 		boolean influxDBstarted = false;
 		do {
 			Pong response;

--- a/src/test/java/org/influxdb/PerformanceTests.java
+++ b/src/test/java/org/influxdb/PerformanceTests.java
@@ -18,8 +18,7 @@ public class PerformanceTests {
 
 	@BeforeClass
 	public void setUp() {
-		String ip = "127.0.0.1";
-		this.influxDB = InfluxDBFactory.connect("http://" + ip + ":8086", "root", "root");
+		this.influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":8086", "root", "root");
 		this.influxDB.setLogLevel(LogLevel.NONE);
 	}
 

--- a/src/test/java/org/influxdb/TestUtils.java
+++ b/src/test/java/org/influxdb/TestUtils.java
@@ -1,0 +1,18 @@
+package org.influxdb;
+
+import java.util.Map;
+
+public class TestUtils {
+
+	public static String getInfluxIP() {
+		String ip = "127.0.0.1";
+		
+		Map<String, String> getenv = System.getenv();
+		if (getenv.containsKey("INFLUXDB_IP")) {
+			ip = getenv.get("INFLUXDB_IP");
+		}
+		
+		return ip;
+	}
+
+}

--- a/src/test/java/org/influxdb/TicketTests.java
+++ b/src/test/java/org/influxdb/TicketTests.java
@@ -44,7 +44,7 @@ public class TicketTests {
 		DockerClientConfig config = DockerClientConfig
 				.createDefaultConfigBuilder()
 				.withVersion("1.16")
-				.withUri("tcp://localhost:4243")
+				.withUri("tcp://" + TestUtils.getInfluxIP() + ":4243")
 				.withUsername("roott")
 				.withPassword("root")
 				.build();

--- a/src/test/java/org/influxdb/impl/InfluxDBErrorHandlerTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBErrorHandlerTest.java
@@ -2,6 +2,8 @@ package org.influxdb.impl;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
+
+import org.influxdb.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import retrofit.RetrofitError;
@@ -19,7 +21,7 @@ public class InfluxDBErrorHandlerTest {
     @Test
     public void testHandleErrorAndCloseTheStream() {
         final String influxDbInternalError = "InfluxDB internal error";
-        String url = "http://localhost:8096";
+        String url = "http://" + TestUtils.getInfluxIP() + ":8096";
 
         final AtomicBoolean closed = new AtomicBoolean(false);
         Response response = new Response(url, 500, "Internal error",


### PR DESCRIPTION
This allows the tests to be run against an InfluxDB at any IP address. I
needed this because I am running my InfluxDB inside a Docker container
which is running inside a `docker-machine` VM.

These changes look for `INFLUXDB_IP` in the system environment for the
IP to use, falling back to localhost (127.0.0.1) if the key is not
specified.

On a Mac, from the command line do something like:

  $ export INFLUXDB_IP=www.xxx.yyy.zzz
  $ mvn test

In Eclipse, add an item to your "run configuration's" environment
variables.