### PR TITLE
Refactoring dependencies

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -6,12 +6,11 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 
@@ -54,10 +53,10 @@ public class Point {
 	 */
 	public static final class Builder {
 		private final String measurement;
-		private final Map<String, String> tags = Maps.newTreeMap(Ordering.natural());
+		private final Map<String, String> tags = new TreeMap<>();
 		private Long time;
 		private TimeUnit precision = TimeUnit.NANOSECONDS;
-		private final Map<String, Object> fields = Maps.newTreeMap(Ordering.natural());
+		private final Map<String, Object> fields = new TreeMap<>();
 		
 		/**
 		 * @param measurement


### PR DESCRIPTION
The TreeMap can be used without using com.google.common.collect.Maps. There is also no need of com.google.common.collect.Ordering because the String already implements Comparable by itself and a TreeMap is already sorted.

Signed-off-by: Florin Asavoaie <florin.asavoaie@gmail.com>