### PR TITLE
Using thread-safe data structures in Point class

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -1,19 +1,20 @@
 package org.influxdb.dto;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Ordering;
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
-import com.google.common.escape.Escaper;
-import com.google.common.escape.Escapers;
 
 /**
  * Representation of a InfluxDB database Point.
@@ -54,10 +55,10 @@ public class Point {
 	 */
 	public static final class Builder {
 		private final String measurement;
-		private final Map<String, String> tags = Maps.newTreeMap(Ordering.natural());
+		private final Map<String, String> tags = new ConcurrentSkipListMap<>(Ordering.natural());
 		private Long time;
 		private TimeUnit precision = TimeUnit.NANOSECONDS;
-		private final Map<String, Object> fields = Maps.newTreeMap(Ordering.natural());
+		private final Map<String, Object> fields = new ConcurrentHashMap<>();
 		
 		/**
 		 * @param measurement


### PR DESCRIPTION
Changes made to Point class. Changed tag Map to ConcurrentSkipListMap which is thread safe and also supports natural ordering. Changed tag Map to ConcurrentHashMap. (Regarding the issue #170) 
https://github.com/influxdata/influxdb-java/issues/170