### PR TITLE
Data Loss bugfix / Additional Features

### DIFF
--- a/src/main/java/org/influxdb/dto/BatchPoints.java
+++ b/src/main/java/org/influxdb/dto/BatchPoints.java
@@ -1,15 +1,14 @@
 package org.influxdb.dto;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import org.influxdb.InfluxDB.ConsistencyLevel;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
+import org.influxdb.InfluxDB.ConsistencyLevel;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * {Purpose of This Type}
@@ -97,11 +96,11 @@ public class BatchPoints {
 		/**
 		 * Add a set of Points to this set of points.
 		 *
-		 * @param pointsToAdd
+		 * @param pointList
 		 * @return the Builder instance
 		 */
-		public Builder points(final Point... pointsToAdd) {
-			this.points.addAll(Arrays.asList(pointsToAdd));
+		public Builder points(List<Point> pointList) {
+			this.points.addAll(pointList);
 			return this;
 		}
 

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -354,7 +354,7 @@ public class Point {
 			sb.append(KEY_ESCAPER.escape(field.getKey())).append("=");
 			if (value instanceof String) {
 				String stringValue = (String) value;
-				stringValue = stringValue.replaceAll("\\\\", "//");
+				stringValue = stringValue.replace("\\", "/");
 				sb.append("\"").append(FIELD_ESCAPER.escape(stringValue)).append("\"");
 			} else if (value instanceof Number) {
 				if (value instanceof Double || value instanceof Float || value instanceof BigDecimal) {

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -1,19 +1,20 @@
 package org.influxdb.dto;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.NumberFormat;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.NumberFormat;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Representation of a InfluxDB database Point.
@@ -150,13 +151,43 @@ public class Point {
 		}
 		
 		public Builder addField(final String field, final String value) {
-			if (value == null) {
-				throw new IllegalArgumentException("Field value cannot be null");
-			}
-			
 			fields.put(field, value);
 			return this;
 		}
+
+
+		public Builder addField(final String field, final boolean value, final boolean activated) {
+			if (activated)
+				fields.put(field, value);
+			return this;
+		}
+
+		public Builder addField(final String field, final long value, final boolean activated) {
+			if (activated)
+				fields.put(field, value);
+			return this;
+		}
+
+		public Builder addField(final String field, final double value, final boolean activated) {
+			if (activated)
+				fields.put(field, value);
+			return this;
+		}
+
+		public Builder addField(String field, Number value, final boolean activated) {
+			if (activated)
+				fields.put(field, value);
+			return this;
+		}
+
+		public Builder addField(final String field, final String value, final boolean activated) {
+			if (activated)
+				fields.put(field, value);
+			return this;
+		}
+
+
+
 		
 		/**
 		 * Add a Map of fields to this point.
@@ -303,8 +334,8 @@ public class Point {
 		return sb;
 	}
 	
-	private StringBuilder concatenateFields() {
-		final StringBuilder sb = new StringBuilder();
+	private String concatenateFields() {
+		final StringJoiner joiner = new StringJoiner(",");
 		final int fieldCount = this.fields.size();
 		int loops = 0;
 
@@ -314,7 +345,7 @@ public class Point {
 		numberFormat.setMinimumFractionDigits(1);
 
 		for (Entry<String, Object> field : this.fields.entrySet()) {
-			loops++;
+			StringBuilder sb = new StringBuilder();
 			Object value = field.getValue();
 			if (value == null) {
 				continue;
@@ -335,11 +366,15 @@ public class Point {
 			}
 
 			if (loops < fieldCount) {
-				sb.append(",");
+				joiner.add(sb.toString());
 			}
+			loops++;
 		}
 
-		return sb;
+		if (joiner.toString().length() == 0)
+			throw new IllegalArgumentException("There must be at least one field as an input that is not null");
+
+		return joiner.toString();
 	}
 
 	private StringBuilder formatedTime() {

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -354,6 +354,7 @@ public class Point {
 			sb.append(KEY_ESCAPER.escape(field.getKey())).append("=");
 			if (value instanceof String) {
 				String stringValue = (String) value;
+				stringValue = stringValue.replaceAll("\\\\", "//");
 				sb.append("\"").append(FIELD_ESCAPER.escape(stringValue)).append("\"");
 			} else if (value instanceof Number) {
 				if (value instanceof Double || value instanceof Float || value instanceof BigDecimal) {

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -142,8 +142,6 @@ public class BatchProcessor {
 		this.scheduler.scheduleAtFixedRate(new Runnable() {
 			@Override
 			public void run() {
-				//ToDo if write is activated here, a deadlock between scheduler and main thread is possible
-				//ToDo write BatchProcessor with either an action limit or with a flushInterval
 				write();
 			}
 		}, this.flushInterval, this.flushInterval, this.flushIntervalUnit);

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -1,22 +1,17 @@
 package org.influxdb.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A BatchProcessor can be attached to a InfluxDB Instance to collect single point writes and
@@ -173,9 +168,8 @@ public class BatchProcessor {
 				BatchProcessor.this.influxDB.write(batchPoints);
 			}
 
-		} catch (Exception t) {
+		} catch (Throwable t) {
 			// any exception would stop the scheduler
-			t.printStackTrace();
 			logger.log(Level.SEVERE, "Batch could not be sent. Data will be lost", t);
 		}
 	}

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -160,7 +160,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final String records) {
+	synchronized public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final String records) {
 		this.influxDBService.writePoints(
 				this.username,
 				this.password,
@@ -171,7 +171,7 @@ public class InfluxDBImpl implements InfluxDB {
 				new TypedString(records));
 	}
 	@Override
-	public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final List<String> records) {
+	synchronized public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final List<String> records) {
 		final String joinedRecords = Joiner.on("\n").join(records);
 		write(database, retentionPolicy, consistency, joinedRecords);
 	}

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -1,28 +1,22 @@
 package org.influxdb.impl;
 
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.google.common.base.Joiner;
-import org.influxdb.InfluxDB;
-import org.influxdb.dto.BatchPoints;
-import org.influxdb.dto.Point;
-import org.influxdb.dto.Pong;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.influxdb.impl.BatchProcessor.BatchEntry;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
-
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.*;
+import org.influxdb.impl.BatchProcessor.BatchEntry;
 import retrofit.RestAdapter;
 import retrofit.client.Client;
 import retrofit.client.Header;
 import retrofit.client.Response;
 import retrofit.mime.TypedString;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Implementation of a InluxDB API.
@@ -131,7 +125,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	synchronized public void write(final String database, final String retentionPolicy, final Point point) {
+	public void write(final String database, final String retentionPolicy, final Point point) {
 		if (this.batchEnabled.get()) {
 			BatchEntry batchEntry = new BatchEntry(point, database, retentionPolicy);
 			this.batchProcessor.put(batchEntry);
@@ -145,7 +139,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	synchronized public void write(final BatchPoints batchPoints) {
+	public void write(final BatchPoints batchPoints) {
 		this.batchedCount.addAndGet(batchPoints.getPoints().size());
 		TypedString lineProtocol = new TypedString(batchPoints.lineProtocol());
 		this.influxDBService.writePoints(
@@ -160,7 +154,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	synchronized public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final String records) {
+	public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final String records) {
 		this.influxDBService.writePoints(
 				this.username,
 				this.password,
@@ -171,7 +165,7 @@ public class InfluxDBImpl implements InfluxDB {
 				new TypedString(records));
 	}
 	@Override
-	synchronized public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final List<String> records) {
+	public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency, final List<String> records) {
 		final String joinedRecords = Joiner.on("\n").join(records);
 		write(database, retentionPolicy, consistency, joinedRecords);
 	}

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -131,7 +131,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	public void write(final String database, final String retentionPolicy, final Point point) {
+	synchronized public void write(final String database, final String retentionPolicy, final Point point) {
 		if (this.batchEnabled.get()) {
 			BatchEntry batchEntry = new BatchEntry(point, database, retentionPolicy);
 			this.batchProcessor.put(batchEntry);
@@ -145,7 +145,7 @@ public class InfluxDBImpl implements InfluxDB {
 	}
 
 	@Override
-	public void write(final BatchPoints batchPoints) {
+	synchronized public void write(final BatchPoints batchPoints) {
 		this.batchedCount.addAndGet(batchPoints.getPoints().size());
 		TypedString lineProtocol = new TypedString(batchPoints.lineProtocol());
 		this.influxDBService.writePoints(

--- a/src/test/java/org/influxdb/dto/WriteTest.java
+++ b/src/test/java/org/influxdb/dto/WriteTest.java
@@ -1,0 +1,108 @@
+package org.influxdb.dto;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for Writing Data
+ *
+ * @author Daniel700
+ */
+@Test
+public class WriteTest {
+
+    private InfluxDB influxDB;
+    private String database = "testDB";
+
+    @BeforeClass
+    public void setUp(){
+        this.influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":8086", "root", "root");
+        influxDB.createDatabase(database);
+    }
+
+
+    @Test
+    public void testLineProtocolWithConditionalValues(){
+        BatchPoints batchPoints = BatchPoints.database(database).build();
+        boolean condition = false;
+
+        for (int i = 0; i < 10; i++){
+            if (i%2 == 0) {
+                condition = true;
+            }
+            else
+                condition = false;
+
+            Point point = Point.measurement("condEvents")
+                    .tag("tag1", "abc")
+                    .addField("field1", 1)
+                    .addField("field2", 2.5, condition)
+                    .time(System.nanoTime(), TimeUnit.NANOSECONDS)
+                    .build();
+
+            batchPoints.point(point);
+        }
+        influxDB.write(batchPoints);
+
+        Query query = new Query("Select Count(field1) from condEvents", database);
+        QueryResult result = influxDB.query(query);
+        String count = result.getResults().get(0).getSeries().get(0).getValues().get(0).toString();
+        String parts[] = count.split(",");
+        Query query1 = new Query("Select Count(field2) from condEvents", database);
+        QueryResult result1 = influxDB.query(query1);
+        String count2 = result1.getResults().get(0).getSeries().get(0).getValues().get(0).toString();
+        String parts2[] = count2.split(",");
+
+        Assert.assertEquals(parts[1].trim(),"10.0]");
+        Assert.assertEquals(parts2[1].trim(),"5.0]");
+    }
+
+
+    @Test
+    public void testValidateBatchProcessor(){
+        influxDB.enableBatch(5000, 5, TimeUnit.SECONDS);
+
+        for (int i = 0; i < 400000; i++){
+            Point point = Point.measurement("batchEvents")
+                    .time(System.nanoTime(), TimeUnit.NANOSECONDS)
+                    .tag("tag1", "abc")
+                    .addField("field1", i)
+                    .build();
+
+            influxDB.write(database, "default", point);
+
+            if (i%50000 == 0)
+                System.out.println(i);
+
+        }
+
+        try {
+            Thread.sleep(5000);
+        }
+        catch (InterruptedException e){
+            System.out.println("ex");
+        }
+
+
+        Query query = new Query("Select Count(field1) from batchEvents", database);
+        QueryResult result = influxDB.query(query);
+        String count = result.getResults().get(0).getSeries().get(0).getValues().get(0).toString();
+        String parts[] = count.split(",");
+        Assert.assertEquals(parts[1].trim(), "400000.0]");
+    }
+
+
+
+    @AfterClass
+    public void tearDown(){
+        influxDB.deleteDatabase(database);
+    }
+
+}

--- a/src/test/java/org/influxdb/dto/WriteTest.java
+++ b/src/test/java/org/influxdb/dto/WriteTest.java
@@ -76,6 +76,8 @@ public class WriteTest {
                     .time(i, TimeUnit.NANOSECONDS)
                     .tag("tag1", "abc")
                     .addField("field1", i)
+                    .addField("field2", "test abc\\nde\\basd\\tge\\rasd\\ffewg\\'ger\\")
+                    .addField("field3", "C:\\Users\\ADM~1\\AppData\\Local\\Temp\\nsm192C.tmp\\nsExec.dll")
                     .build();
 
             influxDB.write(database, "default", point);
@@ -106,6 +108,8 @@ public class WriteTest {
                     .time(i, TimeUnit.NANOSECONDS)
                     .tag("tag1", "abc")
                     .addField("field1", i)
+                    .addField("field2", "test abc\\nde\\basd\\tge\\rasd\\ffewg\\'ger\\")
+                    .addField("field3", "C:\\Users\\ADM~1\\AppData\\Local\\Temp\\nsm192C.tmp\\nsExec.dll")
                     .build();
 
             batchPoints.point(point);

--- a/src/test/java/org/influxdb/dto/WriteTest.java
+++ b/src/test/java/org/influxdb/dto/WriteTest.java
@@ -67,7 +67,8 @@ public class WriteTest {
 
     @Test
     public void testValidateBatchProcessor() throws InterruptedException{
-        influxDB.enableBatch(25000, 300, TimeUnit.MILLISECONDS);
+        int flushInterval = 800;
+        influxDB.enableBatch(25000, flushInterval, TimeUnit.MILLISECONDS);
         int numberOfEvents = 5100000;
 
         for (int i = 1; i <= numberOfEvents; i++){
@@ -82,6 +83,9 @@ public class WriteTest {
             if (i%50000 == 0)
                 System.out.println(i);
         }
+
+        //Wait for terminating all writes
+        Thread.sleep(flushInterval*3);
 
         Query query = new Query("Select Count(field1) from batchEvents", database);
         QueryResult result = influxDB.query(query);


### PR DESCRIPTION
I guess that I've found the bugfix for the data loss problem:
The data loss happens if you send field values as strings which contain a backslash following with a java specific escape sequence. (See here: [Escape Sequences](http://docs.oracle.com/javase/tutorial/java/data/characters.html))
The line protocol interprets then for example `sometext\newtext` with `\n` as a new line.
That's why I have added line 357 `stringValue = stringValue.replace("\\", "/");` in Point.java as a quick fix. If you want a more sophisticated solution it's up to you. But it seems to work.

Moreover, you dont have to check the field (String) value for null in the `addField()` method (line 154 in Point.java) because you should also be able to add fields with null values. You just have to check that during the `concatenateFields()` method that you have at least one field with a value. There was also a bug in building the concatenated String if you pass null values (as a Number for example) that you had a comma at the end of the concatenated string where no comma should appear because no field has been added. 

I have also added an additional Feature to addFields on basis of a condition. Since InfluxDB is a schemaless DB you don't need always to add every field to the Point class and transmit it to the Server. Please check the tests in the `WriteTest.java` class 