### PR TITLE
Fixed database creation for influxDB version 1.0.0.

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -202,7 +202,7 @@ public class InfluxDBImpl implements InfluxDB {
 	@Override
 	public void createDatabase(final String name) {
 		Preconditions.checkArgument(!name.contains("-"), "Databasename cant contain -");
-		this.influxDBService.query(this.username, this.password, "CREATE DATABASE IF NOT EXISTS \"" + name + "\"");
+		this.influxDBService.query(this.username, this.password, "CREATE DATABASE \"" + name + "\"");
 	}
 
 	/**


### PR DESCRIPTION
influxDB version 1.0.0 does not support '... IF NOT EXISTS' term anymore when creating databases.

See: https://docs.influxdata.com/influxdb/v1.0/query_language/database_management/#create-a-database-with-create-database