### PR TITLE
Polishing the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ that allow this to be specified (default is still GET).
 
 ### Maven
 ```
-		<dependency>
-			<groupId>org.influxdb</groupId>
-			<artifactId>influxdb-java</artifactId>
-			<version>2.3</version>
-		</dependency>
+<dependency>
+  <groupId>org.influxdb</groupId>
+  <artifactId>influxdb-java</artifactId>
+  <version>2.3</version>
+</dependency>
 ```
 
 


### PR DESCRIPTION
Maven repository coordinates had too many indentations.

Signed-off-by: Ali Dehghani <ali.dehghani.g@gmail.com>