### PR TITLE
datetime util functions

### DIFF
--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -1,6 +1,8 @@
 package org.influxdb.impl;
 
+import java.text.SimpleDateFormat;
 import java.util.EnumSet;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -42,5 +44,45 @@ public enum TimeUtil {
 			throw new IllegalArgumentException("time precision must be one of:" + allowedTimeunits);
 		}
 	}
+
+    /**
+     * convert a unix epoch time to timestamp used by influxdb. this can then be used in query expressions against influxdb's time column like so:
+     * influxDB.query(new Query("SELECT * FROM some_measurement WHERE time >= '" + toInfluxDBTimeFormat(timeStart) + "'", some_database))
+     * influxdb time format example: 2016-10-31T06:52:20.020Z
+     *
+     * @param time timestamp to use, in unix epoch time
+     * @return influxdb compatible date-tome string
+     */
+    public static String toInfluxDBTimeFormat(long time) {
+        SimpleDateFormat dateDF = new SimpleDateFormat("yyyy-MM-dd");
+        SimpleDateFormat timeDF = new SimpleDateFormat("HH:mm:ss.SSS");
+        dateDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+        timeDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        return dateDF.format(time) + "T" + timeDF.format(time) + "Z";
+    }
+
+    /**
+     * convert an influxdb timestamp used by influxdb to unix epoch time.
+     * influxdb time format example: 2016-10-31T06:52:20.020Z
+     *
+     * @param time timestamp to use, in influxdb datetime format
+     * @return time in unix epoch time
+     */
+    public static long fromInfluxDBTimeFormat(String time) {
+        try {
+            String[] parts = time.split("T");
+            String datePart = parts[0];
+            String timePart = parts[1].substring(0, parts[1].length() - 1);
+            SimpleDateFormat dateDF = new SimpleDateFormat("yyyy-MM-dd");
+            SimpleDateFormat timeDF = new SimpleDateFormat("HH:mm:ss.SSS");
+            dateDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+            timeDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+            return dateDF.parse(datePart).getTime() + timeDF.parse(timePart).getTime();
+        } catch (Exception e) {
+            throw new RuntimeException("unexpected date format", e);
+        }
+    }
 
 }

--- a/src/test/java/org/influxdb/impl/TimeUtilTest.java
+++ b/src/test/java/org/influxdb/impl/TimeUtilTest.java
@@ -1,0 +1,21 @@
+package org.influxdb.impl;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TimeUtilTest {
+    @Test
+    public void toInfluxDBTimeFormatTest() throws Exception {
+        assertThat(TimeUtil.toInfluxDBTimeFormat(1477896740020L), is(equalTo("2016-10-31T06:52:20.020Z")));
+        assertThat(TimeUtil.toInfluxDBTimeFormat(1477932740005L), is(equalTo("2016-10-31T16:52:20.005Z")));
+    }
+
+    @Test
+    public void fromInfluxDBTimeFormatTest() throws Exception {
+        assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T06:52:20.020Z"), is(equalTo(1477896740020L)));
+        assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T16:52:20.005Z"), is(equalTo(1477932740005L)));
+    }
+}


### PR DESCRIPTION
created util functions following issue #217 
implementation only uses Java 7 internal date-time functions. it could have been shorter if JodaTime or Java 8 were used, but I didn't want to change any dependencies / project settings.