### PR TITLE
Checking to see if batchProcessor is null.

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -105,11 +105,13 @@ public class InfluxDBImpl implements InfluxDB {
 	@Override
 	public void disableBatch() {
 		this.batchEnabled.set(false);
-		this.batchProcessor.flush();
-		if (this.logLevel != LogLevel.NONE) {
-			System.out.println(
-					"total writes:" + this.writeCount.get() + " unbatched:" + this.unBatchedCount.get() + "batchPoints:"
-							+ this.batchedCount);
+		if(this.batchProcessor != null) {
+			this.batchProcessor.flush();
+			if (this.logLevel != LogLevel.NONE) {
+				System.out.println(
+						"total writes:" + this.writeCount.get() + " unbatched:" + this.unBatchedCount.get() + "batchPoints:"
+								+ this.batchedCount);
+			}
 		}
 	}
 


### PR DESCRIPTION
Avoids the NPE on line 108 when batching is not enabled for issue #219 . Calling `disableBatch()` has no effect when not enabled.