### PR TITLE
support creating instance without username and password

### DIFF
--- a/src/main/java/org/influxdb/InfluxDBFactory.java
+++ b/src/main/java/org/influxdb/InfluxDBFactory.java
@@ -15,7 +15,21 @@ import okhttp3.OkHttpClient;
  * 
  */
 public enum InfluxDBFactory {
+	
 	;
+	
+	/**
+	 * Create a connection to a InfluxDB.
+	 * 
+	 * @param url
+	 *            the url to connect to.
+	 * @return a InfluxDB adapter suitable to access a InfluxDB.
+	 */
+	public static InfluxDB connect(final String url) {
+		Preconditions.checkArgument(!Strings.isNullOrEmpty(url), "The URL may not be null or empty.");
+		return new InfluxDBImpl(url, null, null, new OkHttpClient.Builder());
+	}
+	
 	/**
 	 * Create a connection to a InfluxDB.
 	 * 
@@ -33,7 +47,21 @@ public enum InfluxDBFactory {
 		Preconditions.checkArgument(!Strings.isNullOrEmpty(username), "The username may not be null or empty.");
 		return new InfluxDBImpl(url, username, password, new OkHttpClient.Builder());
 	}
-
+	
+	/**
+	 * Create a connection to a InfluxDB.
+	 * 
+	 * @param url
+	 *            the url to connect to.
+	 * @param client
+	 * 			  the HTTP client to use
+	 * @return a InfluxDB adapter suitable to access a InfluxDB.
+	 */
+	public static InfluxDB connect(final String url, final OkHttpClient.Builder client) {
+		Preconditions.checkArgument(!Strings.isNullOrEmpty(url), "The URL may not be null or empty.");
+		Preconditions.checkNotNull(client, "The client may not be null.");
+		return new InfluxDBImpl(url, null, null, client);
+	}
 
 	/**
 	 * Create a connection to a InfluxDB.

--- a/src/test/java/org/influxdb/InfluxDBFactoryTest.java
+++ b/src/test/java/org/influxdb/InfluxDBFactoryTest.java
@@ -1,0 +1,41 @@
+package org.influxdb;
+
+import org.influxdb.dto.Pong;
+import org.junit.Assert;
+import org.junit.Test;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Test the InfluxDB Factory API.
+ *
+ * @author fujian1115 [at] gmail.com
+ *
+ */
+public class InfluxDBFactoryTest {
+	
+	/**
+	 * Test for a {@link InfluxDBFactory #connect(String)}.
+	 */
+	@Test
+	public void testCreateInfluxDBInstanceWithoutUserNameAndPassword() {
+		InfluxDB influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":" + TestUtils.getInfluxPORT(true));
+		verifyInfluxDBInstance(influxDB);
+	}
+
+	private void verifyInfluxDBInstance(InfluxDB influxDB) {
+		Assert.assertNotNull(influxDB);
+		Pong pong = influxDB.ping();
+		Assert.assertNotNull(pong);
+		Assert.assertNotEquals(pong.getVersion(), "unknown");
+	}
+
+	/**
+	 * Test for a {@link InfluxDBFactory #connect(String, okhttp3.OkHttpClient.Builder)}.
+	 */
+	@Test
+	public void testCreateInfluxDBInstanceWithClientAndWithoutUserNameAndPassword() {
+		InfluxDB influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":" + TestUtils.getInfluxPORT(true), new OkHttpClient.Builder());
+		verifyInfluxDBInstance(influxDB);
+	}
+}


### PR DESCRIPTION
refer to influxdb offical doc: https://docs.influxdata.com/influxdb/v0.9/administration/authentication_and_authorization/#set-up-authentication
`Authorization is only enforced once you’ve enabled authentication. By default, authentication is disabled, all credentials are silently ignored, and all users have all privileges.`
 So there is no need to set username and password for influxdb which doesn't enable authorization.