### PR TITLE
should break the loop when X-Influxdb-Version found

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -131,6 +131,7 @@ public class InfluxDBImpl implements InfluxDB {
 			for (String name : headers.toMultimap().keySet()) {
 				if (null != name && name.equalsIgnoreCase("X-Influxdb-Version")) {
 					version = headers.get(name);
+					break;
 				}
 			}
 			Pong pong = new Pong();


### PR DESCRIPTION
should break the loop when X-Influxdb-Version found. There is no need to continue the loop due to there is no any other X-Influxdb-Version in headers.