### PR TITLE
support setting thread factory for batch processor

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -1,6 +1,7 @@
 package org.influxdb;
 
 import java.util.List;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdb.dto.BatchPoints;
@@ -90,6 +91,23 @@ public interface InfluxDB {
    * @return the InfluxDB instance to be able to use it in a fluent manner.
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
+
+  /**
+   * Enable Batching of single Point writes to speed up writes significant. If either actions or
+   * flushDurations is reached first, a batchwrite is issued.
+   * Note that batch processing needs to be explicitly stopped before the application is shutdown.
+   * To do so call disableBatch().
+   *
+   * @param actions
+   *            the number of actions to collect
+   * @param flushDuration
+   *            the time to wait at most.
+   * @param flushDurationTimeUnit
+   * @param threadFactory
+   * @return the InfluxDB instance to be able to use it in a fluent manner.
+   */
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit, 
+                              final ThreadFactory threadFactory);
 
   /**
    * Disable Batching.

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -106,7 +106,7 @@ public interface InfluxDB {
    * @param threadFactory
    * @return the InfluxDB instance to be able to use it in a fluent manner.
    */
-  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit, 
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
                               final ThreadFactory threadFactory);
 
   /**

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -78,17 +78,10 @@ public interface InfluxDB {
   public InfluxDB setLogLevel(final LogLevel logLevel);
 
   /**
-   * Enable Batching of single Point writes to speed up writes significant. If either actions or
-   * flushDurations is reached first, a batchwrite is issued.
-   * Note that batch processing needs to be explicitly stopped before the application is shutdown.
-   * To do so call disableBatch().
+   * Enable Batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory)}}
+   * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
    *
-   * @param actions
-   *            the number of actions to collect
-   * @param flushDuration
-   *            the time to wait at most.
-   * @param flushDurationTimeUnit
-   * @return the InfluxDB instance to be able to use it in a fluent manner.
+   * @see #enableBatch(int, int, TimeUnit, ThreadFactory)
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
 

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -47,20 +47,20 @@ public class BatchProcessor {
     private int flushInterval;
 
     /**
-     * @param influxDB
-     *            is mandatory.
-     */
-    public Builder(final InfluxDB influxDB) {
-      this.influxDB = (InfluxDBImpl) influxDB;
-    }
-
-    /**
      * @param threadFactory
      *            is optional.
      */
     public Builder threadFactory(final ThreadFactory threadFactory) {
       this.threadFactory = threadFactory;
       return this;
+    }
+
+    /**
+     * @param influxDB
+     *            is mandatory.
+     */
+    public Builder(final InfluxDB influxDB) {
+      this.influxDB = (InfluxDBImpl) influxDB;
     }
 
     /**
@@ -101,6 +101,7 @@ public class BatchProcessor {
       Preconditions.checkArgument(this.actions > 0, "actions should > 0");
       Preconditions.checkArgument(this.flushInterval > 0, "flushInterval should > 0");
       Preconditions.checkNotNull(this.flushIntervalUnit, "flushIntervalUnit may not be null");
+      Preconditions.checkNotNull(this.threadFactory, "threadFactory may not be null");
       return new BatchProcessor(this.influxDB, this.threadFactory, this.actions, this.flushIntervalUnit,
                                 this.flushInterval);
     }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -27,6 +27,8 @@ import retrofit2.converter.moshi.MoshiConverterFactory;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -91,6 +93,13 @@ public class InfluxDBImpl implements InfluxDB {
   @Override
   public InfluxDB enableBatch(final int actions, final int flushDuration,
                               final TimeUnit flushDurationTimeUnit) {
+    enableBatch(actions, flushDuration, flushDurationTimeUnit, Executors.defaultThreadFactory());
+    return this;
+  }
+
+  @Override
+  public InfluxDB enableBatch(final int actions, final int flushDuration,
+                              final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory) {
     if (this.batchEnabled.get()) {
       throw new IllegalArgumentException("BatchProcessing is already enabled.");
     }
@@ -98,6 +107,7 @@ public class InfluxDBImpl implements InfluxDB {
         .builder(this)
         .actions(actions)
         .interval(flushDuration, flushDurationTimeUnit)
+        .threadFactory(threadFactory)
         .build();
     this.batchEnabled.set(true);
     return this;

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -1,21 +1,18 @@
 package org.influxdb;
 
+import org.influxdb.InfluxDB.LogLevel;
+import org.influxdb.dto.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
-import org.influxdb.InfluxDB.LogLevel;
-import org.influxdb.dto.BatchPoints;
-import org.influxdb.dto.Point;
-import org.influxdb.dto.Pong;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Test the InfluxDB API.
@@ -229,7 +226,7 @@ public class InfluxDBTest {
 	 */
 	@Test
 	public void testBatchEnabledWithThreadFactory() {
- 		final String threadName = "async_influxdb_write";
+		final String threadName = "async_influxdb_write";
 		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS, new ThreadFactory() {
 			
 			@Override
@@ -251,4 +248,10 @@ public class InfluxDBTest {
 		Assert.assertTrue(existThreadWithSettedName);
 		this.influxDB.disableBatch();
 	}
+
+	@Test(expected = NullPointerException.class)
+	public void testBatchEnabledWithThreadFactoryIsNull() {
+		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS, null);
+	}
+
 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -1,16 +1,21 @@
 package org.influxdb;
 
-import org.influxdb.InfluxDB.LogLevel;
-import org.influxdb.dto.*;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+
+import org.influxdb.InfluxDB.LogLevel;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Pong;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test the InfluxDB API.
@@ -217,5 +222,33 @@ public class InfluxDBTest {
 
 		this.influxDB.disableBatch();
 		Assert.assertFalse(this.influxDB.isBatchEnabled());
+	}
+	
+	/**
+	 * Test the implementation of {@link InfluxDB#enableBatch(int, int, TimeUnit, ThreadFactory)}.
+	 */
+	@Test
+	public void testBatchEnabledWithThreadFactory() {
+ 		final String threadName = "async_influxdb_write";
+		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS, new ThreadFactory() {
+			
+			@Override
+			public Thread newThread(Runnable r) {
+				Thread thread = new Thread(r);
+				thread.setName(threadName);
+				return thread;
+			}
+		});
+		Set<Thread> threads = Thread.getAllStackTraces().keySet();
+		boolean existThreadWithSettedName = false;
+		for(Thread thread: threads){
+			if(thread.getName().equalsIgnoreCase(threadName)){
+				existThreadWithSettedName = true;
+				break;
+			}
+			
+		}
+		Assert.assertTrue(existThreadWithSettedName);
+		this.influxDB.disableBatch();
 	}
 }


### PR DESCRIPTION
[Motivation]

batch processor's thread can't be set with name or isDamen and so on. It is hard to figure out which thread is for influxdb and take some customized actions.

[Modifications]
add thread factory into processor's builder class and all another method for enable batch.

[Result]
the batch processor's thread can be customized.