### PR TITLE
remove duplicated check for time is null

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -181,7 +181,7 @@ public class Point {
      * @return the Builder instance.
      */
     public Builder time(final long timeToSet, final TimeUnit precisionToSet) {
-        Preconditions.checkNotNull(precisionToSet, "Precision must be not null!");
+      Preconditions.checkNotNull(precisionToSet, "Precision must be not null!");
       this.time = timeToSet;
       this.precision = precisionToSet;
       return this;
@@ -352,9 +352,6 @@ public class Point {
 
   private StringBuilder formatedTime() {
     final StringBuilder sb = new StringBuilder();
-    if (null == this.time) {
-      this.time = this.precision.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-    }
     sb.append(" ").append(TimeUnit.NANOSECONDS.convert(this.time, this.precision));
     return sb;
   }


### PR DESCRIPTION
in builder's build, it had checked the time is null so that the time for point never be null. So it can be removed to avoid duplicated check and improve the code coverage.