### PR TITLE
correct exception type for batch enable

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -118,7 +118,7 @@ public class InfluxDBImpl implements InfluxDB {
   public InfluxDB enableBatch(final int actions, final int flushDuration,
                               final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory) {
     if (this.batchEnabled.get()) {
-      throw new IllegalArgumentException("BatchProcessing is already enabled.");
+      throw new IllegalStateException("BatchProcessing is already enabled.");
     }
     this.batchProcessor = BatchProcessor
         .builder(this)

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -330,6 +330,16 @@ public class InfluxDBTest {
 		InfluxDBFactory.connect("http://" + errorHost + ":" + TestUtils.getInfluxPORT(true));
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void testBatchEnabledTwice() {
+		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS);
+		try{
+			this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS);
+		} finally {
+			this.influxDB.disableBatch();
+		}
+	}
+
 	/**
 	 * Test the implementation of {@link InfluxDB#close()}.
 	 */


### PR DESCRIPTION
@majst01  when enable batch twice, it is not error about illegal arguments but state. so we may need to change the exception type to right one.