### PR TITLE
prepare code changes to support UDP async

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -12,7 +12,7 @@ import org.influxdb.dto.Point;
 import org.influxdb.dto.Pong;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.influxdb.impl.BatchProcessor.BatchEntry;
+import org.influxdb.impl.BatchProcessor.HttpBatchEntry;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -180,7 +180,7 @@ public class InfluxDBImpl implements InfluxDB {
   @Override
   public void write(final String database, final String retentionPolicy, final Point point) {
     if (this.batchEnabled.get()) {
-      BatchEntry batchEntry = new BatchEntry(point, database, retentionPolicy);
+      HttpBatchEntry batchEntry = new HttpBatchEntry(point, database, retentionPolicy);
       this.batchProcessor.put(batchEntry);
     } else {
       BatchPoints batchPoints = BatchPoints.database(database)

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -170,8 +170,8 @@ public class InfluxDBTest {
     public void testWriteStringDataThroughUDP() {
         String measurement = TestUtils.getRandomMeasurement();
         this.influxDB.write(UDP_PORT, measurement + ",atag=test idle=90,usertime=9,system=1");
-        //write with UDP may be executed on server after query with HTTP. so sleep 1s to handle this case
-        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+        //write with UDP may be executed on server after query with HTTP. so sleep 2s to handle this case
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         Query query = new Query("SELECT * FROM " + measurement + " GROUP BY *", UDP_DATABASE);
         QueryResult result = this.influxDB.query(query);
         Assert.assertFalse(result.getResults().get(0).getSeries().get(0).getTags().isEmpty());

--- a/src/test/java/org/influxdb/impl/BatchProcessorTest.java
+++ b/src/test/java/org/influxdb/impl/BatchProcessorTest.java
@@ -25,8 +25,8 @@ public class BatchProcessorTest {
         doThrow(new RuntimeException()).when(mockInfluxDB).write(any(BatchPoints.class));
 
         Point point = Point.measurement("cpu").field("6", "").build();
-        BatchProcessor.BatchEntry batchEntry1 = new BatchProcessor.BatchEntry(point, "db1", "");
-        BatchProcessor.BatchEntry batchEntry2 = new BatchProcessor.BatchEntry(point, "db2", "");
+        BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "");
+        BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db2", "");
 
         batchProcessor.put(batchEntry1);
         Thread.sleep(200); // wait for scheduler


### PR DESCRIPTION
This is another PR to prepare supporting UDP async. 
Create this PR's goal to make sure we can step by step with limit code changes for clear review.

abstract batch entry to support both http batch entry and udp batch entry.

This will avoid use the same batch entry due to http batch entry doesn't  need udp port and udp patch doesn't need dbname or rp.

I doesn't add any unit tests(so decrease coverage by 0.42%) due to just refactor and no use the **UdpBatchEntry** just now. it is just one common java bean without any logical.
I will add tests together with the next PR when support UDP patch officially.