### PR TITLE
support gzip for http request to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ influxDB.deleteDatabase(dbName);
 ```
 Note that the batching functionality creates an internal thread pool that needs to be shutdown explicitly as part of a gracefull application shut-down, or the application will not shut down properly. To do so simply call: ```influxDB.close()```
 
+influxdb-java client doesn't enable gzip compress for http request body by default. If you want to enable gzip to reduce transfter data's size , you can call: ```influxDB.enableGzip()```
+
 ### Changes in 2.4
 influxdb-java now uses okhttp3 and retrofit2.  As a result, you can now pass an ``OkHttpClient.Builder``
 to the ``InfluxDBFactory.connect`` if you wish to add more interceptors, etc, to OkHttp.

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -78,6 +78,21 @@ public interface InfluxDB {
   public InfluxDB setLogLevel(final LogLevel logLevel);
 
   /**
+   * Enable Gzip compress for http request body.
+   */
+  public InfluxDB enableGzip();
+
+  /**
+   * Disable Gzip compress for http request body.
+   */
+  public InfluxDB disableGzip();
+
+  /**
+   * Returns whether Gzip compress for http request body is enabled.
+   */
+  public boolean isGzipEnabled();
+
+  /**
    * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory)}}
    * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
    *

--- a/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
+++ b/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
@@ -1,0 +1,76 @@
+package org.influxdb.impl;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+
+/**
+ * Implementation of a intercepter to compress http's body using GZIP.
+ *
+ * @author fujian1115 [at] gmail.com
+ */
+final class GzipRequestInterceptor implements Interceptor {
+
+    private AtomicBoolean enabled = new AtomicBoolean(false);
+
+    GzipRequestInterceptor() {
+    }
+
+    public void enable() {
+        enabled.set(true);
+    }
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public void disable() {
+        enabled.set(false);
+    }
+
+    @Override
+    public Response intercept(Interceptor.Chain chain) throws IOException {
+        if (!enabled.get()) {
+            return chain.proceed(chain.request());
+        }
+
+        Request originalRequest = chain.request();
+        RequestBody body = originalRequest.body();
+        if (body == null || originalRequest.header("Content-Encoding") != null) {
+            return chain.proceed(originalRequest);
+        }
+
+        Request compressedRequest = originalRequest.newBuilder().header("Content-Encoding", "gzip")
+                .method(originalRequest.method(), gzip(body)).build();
+        return chain.proceed(compressedRequest);
+    }
+
+    private RequestBody gzip(final RequestBody body) {
+        return new RequestBody() {
+            @Override
+            public MediaType contentType() {
+                return body.contentType();
+            }
+
+            @Override
+            public long contentLength() {
+                return -1; // We don't know the compressed length in advance!
+            }
+
+            @Override
+            public void writeTo(BufferedSink sink) throws IOException {
+                BufferedSink gzipSink = Okio.buffer(new GzipSink(sink));
+                body.writeTo(gzipSink);
+                gzipSink.close();
+            }
+        };
+    }
+}

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -59,6 +59,7 @@ public class InfluxDBImpl implements InfluxDB {
   private final AtomicLong batchedCount = new AtomicLong();
   private volatile DatagramSocket datagramSocket;
   private final HttpLoggingInterceptor loggingInterceptor;
+  private final GzipRequestInterceptor gzipRequestInterceptor;
   private LogLevel logLevel = LogLevel.NONE;
 
   public InfluxDBImpl(final String url, final String username, final String password,
@@ -69,9 +70,10 @@ public class InfluxDBImpl implements InfluxDB {
     this.password = password;
     this.loggingInterceptor = new HttpLoggingInterceptor();
     this.loggingInterceptor.setLevel(Level.NONE);
+    this.gzipRequestInterceptor = new GzipRequestInterceptor();
     this.retrofit = new Retrofit.Builder()
         .baseUrl(url)
-        .client(client.addInterceptor(loggingInterceptor).build())
+        .client(client.addInterceptor(loggingInterceptor).addInterceptor(gzipRequestInterceptor).build())
         .addConverterFactory(MoshiConverterFactory.create())
         .build();
     this.influxDBService = this.retrofit.create(InfluxDBService.class);
@@ -105,6 +107,32 @@ public class InfluxDBImpl implements InfluxDB {
     }
     this.logLevel = logLevel;
     return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public InfluxDB enableGzip() {
+    this.gzipRequestInterceptor.enable();
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public InfluxDB disableGzip() {
+    this.gzipRequestInterceptor.disable();
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isGzipEnabled() {
+    return this.gzipRequestInterceptor.isEnabled();
   }
 
   @Override


### PR DESCRIPTION
as titled:

as I tested:
we can compare the content length be reduced from 2121 to 480. **it is big improvement for write's performance** though it may take more cpu time:

![final_gzip_compare](https://cloud.githubusercontent.com/assets/5654180/20203361/a5dd4672-a801-11e6-9b9f-c2cbb8b36cc0.jpg)

and the content be compressed to gzip:
![final_gzip_1](https://cloud.githubusercontent.com/assets/5654180/20203362/a5debc78-a801-11e6-8128-f6e7a5dcb4bb.jpg)

The original content is as followed:
```
                    "cpu,atag=test1 idle=100,usertime=10,system=1",
                    "cpu,atag=test2 idle=200,usertime=20,system=2",
                    "cpu,atag=test3 idle=300,usertime=30,system=3"
...............................more lines------------------------
```

@majst01 Thanks for your review!