### PR TITLE
support writing Point by async/sync through UDP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,18 @@ influxDB.deleteDatabase(dbName);
 ```
 Note that the batching functionality creates an internal thread pool that needs to be shutdown explicitly as part of a gracefull application shut-down, or the application will not shut down properly. To do so simply call: ```influxDB.close()```
 
+Gzip's support:
+
 influxdb-java client doesn't enable gzip compress for http request body by default. If you want to enable gzip to reduce transfter data's size , you can call: ```influxDB.enableGzip()```
+
+UDP's support:
+
+influxdb-java client support udp protocol now. you can call followed methods directly to wirte through UDP.
+```
+public void write(final int udpPort, final String records);
+public void write(final int udpPort, final List<String> records);
+public void write(final int udpPort, final Point point);
+```
 
 ### Changes in 2.4
 influxdb-java now uses okhttp3 and retrofit2.  As a result, you can now pass an ``OkHttpClient.Builder``

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -154,6 +154,16 @@ public interface InfluxDB {
   public void write(final String database, final String retentionPolicy, final Point point);
 
   /**
+   * Write a single Point to the database through UDP.
+   *
+   * @param udpPort
+   *            the udpPort to write to.
+   * @param point
+   *            The point to write.
+   */
+  public void write(final int udpPort, final Point point);
+
+  /**
    * Write a set of Points to the influxdb database with the new (>= 0.9.0rc32) lineprotocol.
    *
    * {@linkplain "https://github.com/influxdb/influxdb/pull/2696"}


### PR DESCRIPTION
This PR includes:
(1) support writing Point by async/sync through UDP instead of write string directly.
(2) add unit test
(3) update read me for UDP support

This is the last PR for coding to support UDP not involved UdpBatchUdp if nobody ask for this requirement. 

@majst01  Thanks for you review!
