### PR TITLE
remove the limit for database name: not contain -

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -5,6 +5,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
@@ -340,7 +341,7 @@ public class InfluxDBImpl implements InfluxDB {
    */
   @Override
   public void createDatabase(final String name) {
-    Preconditions.checkArgument(!name.contains("-"), "Database name cant contain -");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(name), "Database name may not be null or empty");
     String createDatabaseQueryString = String.format("CREATE DATABASE \"%s\"", name);
     if (this.version().startsWith("0.")) {
       createDatabaseQueryString = String.format("CREATE DATABASE IF NOT EXISTS \"%s\"", name);

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -308,6 +308,30 @@ public class InfluxDBTest {
 		Assert.assertTrue(result.contains(numericDbName));
 		this.influxDB.deleteDatabase(numericDbName);
 	}
+	
+    /**
+     * Test that creating database which name is empty will throw expected exception
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateEmptyNamedDatabase() {
+        String emptyName = "";
+        this.influxDB.createDatabase(emptyName);
+    }
+
+    /**
+     * Test that creating database which name contains -
+     */
+    @Test()
+    public void testCreateDatabaseWithNameContainHyphen() {
+        String databaseName = "123-456";
+        this.influxDB.createDatabase(databaseName);
+        try {
+            List<String> result = this.influxDB.describeDatabases();
+            Assert.assertTrue(result.contains(databaseName));
+        } finally {
+            this.influxDB.deleteDatabase(databaseName);
+        }
+    }
 
 	/**
 	 * Test the implementation of {@link InfluxDB#isBatchEnabled()}.


### PR DESCRIPTION
@majst01 
refer to https://docs.influxdata.com/influxdb/v1.1/introduction/getting_started/
A fresh install of InfluxDB has no databases (apart from the system _internal), so creating one is our first task. You can create a database with the CREATE DATABASE <db-name> InfluxQL statement, where <db-name> is the name of the database you wish to create. **Names of databases can contain any unicode character as long as the string is double-quoted**. Names can also be left unquoted if they contain only ASCII letters, digits, or underscores and do not begin with a digit.