### PR TITLE
InfluxDB-Java Chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Support writing by UDP protocal.
  - Support gzip compress for http request body.
  - Support setting thread factory for batch processor.
+ - Support chunking
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ public void write(final int udpPort, final Point point);
 ```
 note: make sure write content's total size should not > UDP protocol's limit(64K), or you should use http instead of udp.
 
+
+#### chunking support (version 2.5+ required):
+
+influxdb-java client now supports influxdb chunking. The following example uses a chunkSize of 20 and invokes the specified Consumer (e.g. System.out.println) for each received QueryResult
+```
+Query query = new Query("SELECT idle FROM cpu", dbName);
+influxDB.query(query, 20, queryResult -> System.out.println(queryResult));
+```
+
+
 ### Other Usages:
 For additional usage examples have a look at [InfluxDBTest.java](https://github.com/influxdb/influxdb-java/blob/master/src/test/java/org/influxdb/InfluxDBTest.java "InfluxDBTest.java")
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -3,6 +3,7 @@ package org.influxdb;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
@@ -216,6 +217,18 @@ public interface InfluxDB {
    * @return a List of Series which matched the query.
    */
   public QueryResult query(final Query query);
+
+  /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param consumer
+   *            the consumer to invoke for each received QueryResult
+   */
+    public void query(Query query, int chunkSize, Consumer<QueryResult> consumer);
 
   /**
    * Execute a query against a database.

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -336,17 +336,19 @@ public class InfluxDBImpl implements InfluxDB {
     }
     return execute(call);
   }
-  
+
   /**
    * {@inheritDoc}
    */
   @Override
     public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
 
-        Call<ResponseBody> call = this.influxDBService.query(this.username, this.password, query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
+        Call<ResponseBody> call = this.influxDBService.query(this.username, this.password,
+                query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
+
         call.enqueue(new Callback<ResponseBody>() {
             @Override
-            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+            public void onResponse(final Call<ResponseBody> call, final Response<ResponseBody> response) {
                 if (response.isSuccessful()) {
                     BufferedSource source = null;
                     try {
@@ -372,7 +374,7 @@ public class InfluxDBImpl implements InfluxDB {
             }
 
             @Override
-            public void onFailure(Call<ResponseBody> call, Throwable t) {
+            public void onFailure(final Call<ResponseBody> call, final Throwable t) {
                 throw new RuntimeException(t);
 
             }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -34,6 +34,7 @@ import retrofit2.Response;
 import retrofit2.Retrofit;
 import retrofit2.converter.moshi.MoshiConverterFactory;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -361,6 +362,8 @@ public class InfluxDBImpl implements InfluxDB {
                     try (ResponseBody errorBody = response.errorBody()) {
                         throw new RuntimeException(errorBody.string());
                     }
+                } catch (EOFException e) {
+                    // do nothing
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
@@ -369,7 +372,6 @@ public class InfluxDBImpl implements InfluxDB {
             @Override
             public void onFailure(final Call<ResponseBody> call, final Throwable t) {
                 throw new RuntimeException(t);
-
             }
         });
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -343,6 +343,10 @@ public class InfluxDBImpl implements InfluxDB {
   @Override
     public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
 
+        if (version().startsWith("0.") || version().startsWith("1.0")) {
+            throw new RuntimeException("chunking not supported");
+        }
+
         Call<ResponseBody> call = this.influxDBService.query(this.username, this.password,
                 query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
 

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -9,6 +9,7 @@ import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
+import retrofit2.http.Streaming;
 
 interface InfluxDBService {
 
@@ -20,6 +21,7 @@ interface InfluxDBService {
   public static final String PRECISION = "precision";
   public static final String CONSISTENCY = "consistency";
   public static final String EPOCH = "epoch";
+  public static final String CHUNK_SIZE = "chunk_size";
 
   @GET("/ping")
   public Call<ResponseBody> ping();
@@ -61,4 +63,8 @@ interface InfluxDBService {
   public Call<QueryResult> postQuery(@Query(U) String username,
       @Query(P) String password, @Query(value = Q, encoded = true) String query);
 
+  @Streaming
+  @GET("/query?chunked=true")
+  public Call<ResponseBody> query(@Query(U) String username, 
+      @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query, @Query(CHUNK_SIZE) int chunkSize);
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -65,6 +65,7 @@ interface InfluxDBService {
 
   @Streaming
   @GET("/query?chunked=true")
-  public Call<ResponseBody> query(@Query(U) String username, 
-      @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query, @Query(CHUNK_SIZE) int chunkSize);
+  public Call<ResponseBody> query(@Query(U) String username,
+      @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query,
+      @Query(CHUNK_SIZE) int chunkSize);
 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -521,7 +521,7 @@ public class InfluxDBTest {
                 }
             }});
         this.influxDB.deleteDatabase(dbName);
-        Assert.assertTrue(countDownLatch.await(1, TimeUnit.SECONDS));
+        Assert.assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
     }
 
     /**
@@ -542,7 +542,7 @@ public class InfluxDBTest {
             }
         });
         this.influxDB.deleteDatabase(dbName);
-        Assert.assertFalse(countDownLatch.await(1, TimeUnit.SECONDS));
+        Assert.assertFalse(countDownLatch.await(10, TimeUnit.SECONDS));
     }
 
 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -532,10 +532,12 @@ public class InfluxDBTest {
 
         QueryResult result = queue.poll(20, TimeUnit.SECONDS);
         Assert.assertNotNull(result);
+        System.out.println(result);
         Assert.assertEquals(2, result.getResults().get(0).getSeries().get(0).getValues().size());
 
         result = queue.poll(20, TimeUnit.SECONDS);
         Assert.assertNotNull(result);
+        System.out.println(result);
         Assert.assertEquals(1, result.getResults().get(0).getSeries().get(0).getValues().size());
     }
 

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -511,7 +511,7 @@ public class InfluxDBTest {
         String dbName = "write_unittest_" + System.currentTimeMillis();
         this.influxDB.createDatabase(dbName);
         String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
-        BatchPoints batchPoints = BatchPoints.database(dbName).tag("async", "true").retentionPolicy(rp).build();
+        BatchPoints batchPoints = BatchPoints.database(dbName).retentionPolicy(rp).build();
         Point point1 = Point.measurement("disk").tag("atag", "a").addField("used", 60L).addField("free", 1L).build();
         Point point2 = Point.measurement("disk").tag("atag", "b").addField("used", 70L).addField("free", 2L).build();
         Point point3 = Point.measurement("disk").tag("atag", "c").addField("used", 80L).addField("free", 3L).build();
@@ -520,6 +520,7 @@ public class InfluxDBTest {
         batchPoints.point(point3);
         this.influxDB.write(batchPoints);
 
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         final BlockingQueue<QueryResult> queue = new LinkedBlockingQueue<>();
         Query query = new Query("SELECT * FROM disk", dbName);
         this.influxDB.query(query, 2, new Consumer<QueryResult>() {
@@ -528,6 +529,7 @@ public class InfluxDBTest {
                 queue.add(result);
             }});
 
+        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         this.influxDB.deleteDatabase(dbName);
 
         QueryResult result = queue.poll(20, TimeUnit.SECONDS);

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 
@@ -57,7 +58,7 @@ public class InfluxDBTest {
 		this.influxDB.createDatabase(UDP_DATABASE);
 		// String logs = CharStreams.toString(new InputStreamReader(containerLogsStream,
 		// Charsets.UTF_8));
-		System.out.println("##################################################################################");
+        System.out.println("################################################################################## ");
 		// System.out.println("Container Logs: \n" + logs);
 		System.out.println("#  Connected to InfluxDB Version: " + this.influxDB.version() + " #");
 		System.out.println("##################################################################################");
@@ -219,8 +220,8 @@ public class InfluxDBTest {
     @Test
     public void testWriteMultipleStringDataThroughUDP() {
         String measurement = TestUtils.getRandomMeasurement();
-        this.influxDB.write(UDP_PORT, measurement + ",atag=test1 idle=100,usertime=10,system=1\n" + 
-                                      measurement + ",atag=test2 idle=200,usertime=20,system=2\n" + 
+        this.influxDB.write(UDP_PORT, measurement + ",atag=test1 idle=100,usertime=10,system=1\n" +
+                                      measurement + ",atag=test2 idle=200,usertime=20,system=2\n" +
                                       measurement + ",atag=test3 idle=300,usertime=30,system=3");
         Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         Query query = new Query("SELECT * FROM " + measurement + " GROUP BY *", UDP_DATABASE);
@@ -250,12 +251,12 @@ public class InfluxDBTest {
         Assert.assertEquals(3, result.getResults().get(0).getSeries().size());
         Assert.assertEquals(result.getResults().get(0).getSeries().get(0).getTags().get("atag"), "test1");
         Assert.assertEquals(result.getResults().get(0).getSeries().get(1).getTags().get("atag"), "test2");
-        Assert.assertEquals(result.getResults().get(0).getSeries().get(2).getTags().get("atag"), "test3"); 
+        Assert.assertEquals(result.getResults().get(0).getSeries().get(2).getTags().get("atag"), "test3");
     }
 
     /**
      * When batch of points' size is over UDP limit, the expected exception
-     * is java.lang.RuntimeException: java.net.SocketException: 
+     * is java.lang.RuntimeException: java.net.SocketException:
      * The message is larger than the maximum supported by the underlying transport: Datagram send failed
      * @throws Exception
      */
@@ -485,6 +486,35 @@ public class InfluxDBTest {
         } finally {
             influxDBForTestGzip.close();
         }
+    }
+
+    /**
+     * Test that writing to the new lineprotocol.
+     */
+    @Test
+    public void testChunking() {
+        String dbName = "write_unittest_" + System.currentTimeMillis();
+        this.influxDB.createDatabase(dbName);
+        String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
+        BatchPoints batchPoints = BatchPoints.database(dbName).tag("async", "true").retentionPolicy(rp).build();
+        Point point1 = Point
+                .measurement("cpu")
+                .tag("atag", "test")
+                .addField("idle", 90L)
+                .addField("usertime", 9L)
+                .addField("system", 1L)
+                .build();
+        Point point2 = Point.measurement("disk").tag("atag", "test").addField("used", 80L).addField("free", 1L).build();
+        batchPoints.point(point1);
+        batchPoints.point(point2);
+        this.influxDB.write(batchPoints);
+        Query query = new Query("SELECT * FROM cpu GROUP BY *", dbName);
+        this.influxDB.query(query, 10, new Consumer<QueryResult>() {
+            @Override
+            public void accept(QueryResult result) {
+                Assert.assertFalse(result.getResults().get(0).getSeries().get(0).getTags().isEmpty());
+            }});
+        this.influxDB.deleteDatabase(dbName);
     }
 
 }


### PR DESCRIPTION
Adds support for Chunking, see https://docs.influxdata.com/influxdb/v1.1/guides/querying_data/#chunking

If chunking is enabled multiple QueryResults are delivered through a streaming connection. 

I added a new query method to InfluxDBService that takes a consumer that will process received QueryResults. An example call would look like this.

`        influxDB.query(query, 20, queryResult -> System.out.println(queryResult));`

Would you consider integration this code into master?