### PR TITLE
signal end-of-chunking

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -367,7 +367,9 @@ public class InfluxDBImpl implements InfluxDB {
                         throw new RuntimeException(errorBody.string());
                     }
                 } catch (EOFException e) {
-                    // do nothing
+                    QueryResult queryResult = new QueryResult();
+                    queryResult.setError("DONE");
+                    consumer.accept(queryResult);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -556,6 +556,11 @@ public class InfluxDBTest {
         Assert.assertNotNull(result);
         System.out.println(result);
         Assert.assertEquals(1, result.getResults().get(0).getSeries().get(0).getValues().size());
+
+        result = queue.poll(20, TimeUnit.SECONDS);
+        Assert.assertNotNull(result);
+        System.out.println(result);
+        Assert.assertEquals("DONE", result.getError());
     }
 
     /**


### PR DESCRIPTION
When there are no more QueryResults coming in through chunking we should signal this to the consumer in some way. I suggest that we use some sort of "poison pill" for this. I added a special error message (with text "DONE") to the final QueryResult. I'm open to different options if someone has a better idea.

Thanks!