### PR TITLE
Magnet fixes

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -28,7 +28,10 @@ public class Point {
   private TimeUnit precision = TimeUnit.NANOSECONDS;
   private Map<String, Object> fields;
 
-  private static final Escaper FIELD_ESCAPER = Escapers.builder().addEscape('"', "\\\"").build();
+  private static final Escaper FIELD_ESCAPER = Escapers.builder()
+                                                      .addEscape('\\', "\\\\")
+                                                      .addEscape('"', "\\\"")
+                                                      .build();
   private static final Escaper KEY_ESCAPER = Escapers.builder()
                                                      .addEscape(' ', "\\ ")
                                                      .addEscape(',', "\\,")

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -86,7 +86,9 @@ public class Point {
     public Builder tag(final String tagName, final String value) {
       Preconditions.checkArgument(tagName != null);
       Preconditions.checkArgument(value != null);
-      tags.put(tagName, value);
+      if (!tagName.isEmpty() && !value.isEmpty()) {
+        tags.put(tagName, value);
+      }
       return this;
     }
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
@@ -158,6 +159,10 @@ public class PointTest {
 		// Test escaping of equals sign
 		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar=baz").addField( "a", 1.0 ).build();
 		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\=baz a=1.0 1");
+
+		// Test escaping of escape character
+		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("foo", "test\\test").build();
+		assertThat(point.lineProtocol()).asString().isEqualTo("test foo=\"test\\\\test\" 1");
 	}
 
 	@Test
@@ -218,6 +223,21 @@ public class PointTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullValueThrowsExceptionViaAddField() {
 		Point.measurement("dontcare").addField("field", (String) null);
+	}
+
+	@Test
+	public void testEmptyValuesAreIgnored() {
+		Point point = Point.measurement("dontcare").tag("key","").addField("dontcare", true).build();
+		assertThat(point.getTags().size()).isEqualTo(0);
+
+		point = Point.measurement("dontcare").tag("","value").addField("dontcare", true).build();
+		assertThat(point.getTags().size()).isEqualTo(0);
+
+		point = Point.measurement("dontcare").tag(ImmutableMap.of("key","")).addField("dontcare", true).build();
+		assertThat(point.getTags().size()).isEqualTo(0);
+
+		point = Point.measurement("dontcare").tag(ImmutableMap.of("","value")).addField("dontcare", true).build();
+		assertThat(point.getTags().size()).isEqualTo(0);
 	}
 
 	/**


### PR DESCRIPTION
We encountered some problems with the API.

1. Since some of our keys are based on user input, we noticed the api did not support those if there were backslashes in there
1. Sometimes tag values were empty, which caused influx itself to decline the data with an error