### PR TITLE
Improved end of stream support for chunked responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,16 @@ note: make sure write content's total size should not > UDP protocol's limit(64K
 influxdb-java client now supports influxdb chunking. The following example uses a chunkSize of 20 and invokes the specified Consumer (e.g. System.out.println) for each received QueryResult
 ```
 Query query = new Query("SELECT idle FROM cpu", dbName);
-influxDB.query(query, 20, queryResult -> System.out.println(queryResult));
+influxDB.query(query, 20, new InfluxDBStreamingConsumer() {
+    @Override
+    public void accept(QueryResult result) {
+        System.out.println("result");
+    }             
+    @Override
+    public void completed() {
+        System.out.println("DONE");
+    }
+});
 ```
 
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -3,7 +3,6 @@ package org.influxdb;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
@@ -228,7 +227,7 @@ public interface InfluxDB {
    * @param consumer
    *            the consumer to invoke for each received QueryResult
    */
-    public void query(Query query, int chunkSize, Consumer<QueryResult> consumer);
+    public void query(Query query, int chunkSize, InfluxDBStreamingConsumer consumer);
 
   /**
    * Execute a query against a database.

--- a/src/main/java/org/influxdb/InfluxDBStreamingConsumer.java
+++ b/src/main/java/org/influxdb/InfluxDBStreamingConsumer.java
@@ -1,0 +1,24 @@
+package org.influxdb;
+
+import org.influxdb.dto.QueryResult;
+
+/**
+ * Consumer that will be invoked when executing streaming queries against InfluxDB.
+ *
+ * Created by pjmyburg on 2017/02/13.
+ */
+public interface InfluxDBStreamingConsumer {
+
+    /**
+     * Called for every chunked result received from InfluxDB.
+     *
+     * @param chunk a single QueryResult chunk received from InfluxDB.
+     */
+    void accept(QueryResult chunk);
+
+    /**
+     * Called when the stream is closed.
+     */
+    void completed();
+
+}

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -11,6 +11,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 
 import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBStreamingConsumer;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Pong;
@@ -47,7 +48,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 
 /**
  * Implementation of a InluxDB API.
@@ -341,7 +341,7 @@ public class InfluxDBImpl implements InfluxDB {
    * {@inheritDoc}
    */
   @Override
-    public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
+    public void query(final Query query, final int chunkSize, final InfluxDBStreamingConsumer consumer) {
 
         if (version().startsWith("0.") || version().startsWith("1.0")) {
             throw new RuntimeException("chunking not supported");
@@ -367,9 +367,7 @@ public class InfluxDBImpl implements InfluxDB {
                         throw new RuntimeException(errorBody.string());
                     }
                 } catch (EOFException e) {
-                    QueryResult queryResult = new QueryResult();
-                    queryResult.setError("DONE");
-                    consumer.accept(queryResult);
+                  consumer.completed();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -367,7 +367,7 @@ public class InfluxDBImpl implements InfluxDB {
                         throw new RuntimeException(errorBody.string());
                     }
                 } catch (EOFException e) {
-                  consumer.completed();
+                    consumer.completed();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -561,13 +561,13 @@ public class InfluxDBTest {
                 queue.add(result);
             }
 
-			@Override
-			public void completed() {
-            	QueryResult done = new QueryResult();
-            	done.setError("DONE");
-            	queue.add(done);
-			}
-		});
+            @Override
+            public void completed() {
+                QueryResult done = new QueryResult();
+                done.setError("DONE");
+                queue.add(done);
+            }
+        });
 
         Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
         this.influxDB.deleteDatabase(dbName);
@@ -608,11 +608,11 @@ public class InfluxDBTest {
                 countDownLatch.countDown();
             }
 
-			@Override
-			public void completed() {
-				System.out.println("Completed");
-			}
-		});
+            @Override
+            public void completed() {
+                System.out.println("Completed");
+            }
+        });
         this.influxDB.deleteDatabase(dbName);
         Assert.assertFalse(countDownLatch.await(10, TimeUnit.SECONDS));
     }
@@ -634,10 +634,10 @@ public class InfluxDBTest {
                 public void accept(QueryResult result) {
                 }
 
-				@Override
-				public void completed() {
-				}
-			});
+                @Override
+                public void completed() {
+                }
+            });
         }
     }
 


### PR DESCRIPTION
I've replaced the Java 8 Consumer with a custom interface that allows for a cleaner end of stream notification as opposed to creating a fake error QueryResult.
This also removes the Java 8 dependency.