### PR TITLE
Use java.nio.charset.StandardCharsets instead of guava Charsets

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -1,7 +1,6 @@
 package org.influxdb.impl;
 
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
@@ -41,6 +40,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -290,7 +290,7 @@ public class InfluxDBImpl implements InfluxDB {
   @Override
   public void write(final int udpPort, final String records) {
     initialDatagramSocket();
-    byte[] bytes = records.getBytes(Charsets.UTF_8);
+    byte[] bytes = records.getBytes(StandardCharsets.UTF_8);
     try {
         datagramSocket.send(new DatagramPacket(bytes, bytes.length, hostAddress, udpPort));
     } catch (IOException e) {

--- a/src/test/java/org/influxdb/dto/QueryTest.java
+++ b/src/test/java/org/influxdb/dto/QueryTest.java
@@ -2,13 +2,11 @@ package org.influxdb.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Charsets;
-import com.google.common.primitives.Chars;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -87,6 +85,6 @@ public class QueryTest {
 	}
 
 	private static String decode(String str) throws UnsupportedEncodingException {
-		return URLDecoder.decode(str, Charsets.UTF_8.toString());
+		return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
 	}
 }


### PR DESCRIPTION
As per guava's javadocs:

   <p><b>Note for Java 7 and later:</b> this constant should be treated as deprecated; use
   java.nio.charset.StandardCharsets#UTF_8 instead.
