### PR TITLE
Add InfluxDB.tryWrite(...) methods

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -155,6 +155,18 @@ public interface InfluxDB {
   public void write(final String database, final String retentionPolicy, final Point point);
 
   /**
+   * Try to write a single Point to the database. Useful if batching is enabled with a bounded
+   * <code>actions</code> size: once the maximum batch size is reached, calls to
+   * {@link #tryWrite(String, String, Point)} will return <code>false</code> until the batch is
+   * written to Influx.
+   *
+   * @return <code>true</code> if the point was enqueued or written, <code>false</code> otherwise.
+   *
+   * @see #write(String, String, Point)
+   */
+  public boolean tryWrite(final String database, final String retentionPolicy, final Point point);
+
+  /**
    * Write a single Point to the database through UDP.
    *
    * @param udpPort
@@ -163,6 +175,18 @@ public interface InfluxDB {
    *            The point to write.
    */
   public void write(final int udpPort, final Point point);
+
+  /**
+   * Try to write a single Point to the database through UDP. Useful if batching is enabled with a
+   * bounded <code>actions</code> size: once the maximum batch size is reached, calls to
+   * {@link #tryWrite(int, Point)} will return <code>false</code> until the batch is written to
+   * Influx.
+   *
+   * @return <code>true</code> if the point was enqueued or written, <code>false</code> otherwise.
+   *
+   * @see #write(int, Point)
+   */
+  public boolean tryWrite(final int udpPort, final Point point);
 
   /**
    * Write a set of Points to the influxdb database with the new (>= 0.9.0rc32) lineprotocol.

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -248,14 +248,15 @@ public class BatchProcessor {
     } catch (InterruptedException e) {
         throw new RuntimeException(e);
     }
-    if (this.queue.size() >= this.actions) {
-      this.scheduler.submit(new Runnable() {
-        @Override
-        public void run() {
-          write();
-        }
-      });
+    scheduleWriteIfAtCapacity();
+  }
+
+  boolean offer(final AbstractBatchEntry batchEntry) {
+    if (this.queue.offer(batchEntry)) {
+      scheduleWriteIfAtCapacity();
+      return true;
     }
+    return false;
   }
 
   /**
@@ -268,4 +269,14 @@ public class BatchProcessor {
     this.scheduler.shutdown();
   }
 
+  private void scheduleWriteIfAtCapacity() {
+    if (this.queue.size() >= this.actions) {
+      this.scheduler.submit(new Runnable() {
+        @Override
+        public void run() {
+          write();
+        }
+      });
+    }
+  }
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -235,13 +235,12 @@ public class InfluxDBImpl implements InfluxDB {
    * {@inheritDoc}
    */
   @Override
-  public boolean tryWrite(String database, String retentionPolicy, Point point) {
+  public boolean tryWrite(final String database, final String retentionPolicy, final Point point) {
     boolean written = true;
     if (this.batchEnabled.get()) {
       HttpBatchEntry batchEntry = new HttpBatchEntry(point, database, retentionPolicy);
       written = this.batchProcessor.offer(batchEntry);
-    }
-    else {
+    } else {
       writeDirect(database, retentionPolicy, point);
     }
     this.writeCount.incrementAndGet();
@@ -272,8 +271,7 @@ public class InfluxDBImpl implements InfluxDB {
     if (this.batchEnabled.get()) {
       UdpBatchEntry batchEntry = new UdpBatchEntry(point, udpPort);
       written = this.batchProcessor.offer(batchEntry);
-    }
-    else {
+    } else {
       this.write(udpPort, point.lineProtocol());
       this.unBatchedCount.incrementAndGet();
     }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -226,13 +226,26 @@ public class InfluxDBImpl implements InfluxDB {
       HttpBatchEntry batchEntry = new HttpBatchEntry(point, database, retentionPolicy);
       this.batchProcessor.put(batchEntry);
     } else {
-      BatchPoints batchPoints = BatchPoints.database(database)
-                                           .retentionPolicy(retentionPolicy).build();
-      batchPoints.point(point);
-      this.write(batchPoints);
-      this.unBatchedCount.incrementAndGet();
+      writeDirect(database, retentionPolicy, point);
     }
     this.writeCount.incrementAndGet();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean tryWrite(String database, String retentionPolicy, Point point) {
+    boolean written = true;
+    if (this.batchEnabled.get()) {
+      HttpBatchEntry batchEntry = new HttpBatchEntry(point, database, retentionPolicy);
+      written = this.batchProcessor.offer(batchEntry);
+    }
+    else {
+      writeDirect(database, retentionPolicy, point);
+    }
+    this.writeCount.incrementAndGet();
+    return written;
   }
 
   /**
@@ -248,6 +261,24 @@ public class InfluxDBImpl implements InfluxDB {
       this.unBatchedCount.incrementAndGet();
     }
     this.writeCount.incrementAndGet();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean tryWrite(final int udpPort, final Point point) {
+    boolean written = true;
+    if (this.batchEnabled.get()) {
+      UdpBatchEntry batchEntry = new UdpBatchEntry(point, udpPort);
+      written = this.batchProcessor.offer(batchEntry);
+    }
+    else {
+      this.write(udpPort, point.lineProtocol());
+      this.unBatchedCount.incrementAndGet();
+    }
+    this.writeCount.incrementAndGet();
+    return written;
   }
 
   @Override
@@ -474,4 +505,10 @@ public class InfluxDBImpl implements InfluxDB {
     }
   }
 
+  private void writeDirect(final String database, final String retentionPolicy, final Point point) {
+    BatchPoints batchPoints = BatchPoints.database(database).retentionPolicy(retentionPolicy).build();
+    batchPoints.point(point);
+    this.write(batchPoints);
+    this.unBatchedCount.incrementAndGet();
+  }
 }

--- a/src/test/java/org/influxdb/impl/BatchProcessorTest.java
+++ b/src/test/java/org/influxdb/impl/BatchProcessorTest.java
@@ -14,6 +14,9 @@ import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
 public class BatchProcessorTest {
 
     @Test
@@ -58,20 +61,38 @@ public class BatchProcessorTest {
         verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
     }
 
+    @Test
+    public void testNoBlockOnCapacityExceeded() {
+        InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
+        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(2)
+            .interval(10, TimeUnit.MINUTES).build();
+
+        Point point = Point.measurement("cpu").addField("4", "").build();
+        BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_1");
+        BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_2");
+        BatchProcessor.HttpBatchEntry batchEntry3 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_3");
+
+        assertThat(batchProcessor.offer(batchEntry1), is(true));
+        assertThat(batchProcessor.offer(batchEntry2), is(true));
+        assertThat(batchProcessor.offer(batchEntry3), is(false));
+
+        batchProcessor.flush();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testActionsIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
         BatchProcessor.builder(mockInfluxDB).actions(0)
             .interval(1, TimeUnit.NANOSECONDS).build();
     }
-    
+
     @Test(expected = IllegalArgumentException.class)
     public void testIntervalIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
         BatchProcessor.builder(mockInfluxDB).actions(1)
             .interval(0, TimeUnit.NANOSECONDS).build();
     }
-    
+
     @Test(expected = NullPointerException.class)
     public void testInfluxDBIsNull() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = null;

--- a/src/test/java/org/influxdb/impl/BatchProcessorTest.java
+++ b/src/test/java/org/influxdb/impl/BatchProcessorTest.java
@@ -24,23 +24,27 @@ public class BatchProcessorTest {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
         BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(Integer.MAX_VALUE)
             .interval(1, TimeUnit.NANOSECONDS).build();
+        try {
+            doThrow(new RuntimeException()).when(mockInfluxDB).write(any(BatchPoints.class));
 
-        doThrow(new RuntimeException()).when(mockInfluxDB).write(any(BatchPoints.class));
+            Point point = Point.measurement("cpu").field("6", "").build();
+            BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "");
+            BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db2", "");
 
-        Point point = Point.measurement("cpu").field("6", "").build();
-        BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "");
-        BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db2", "");
+            batchProcessor.put(batchEntry1);
+            Thread.sleep(200); // wait for scheduler
 
-        batchProcessor.put(batchEntry1);
-        Thread.sleep(200); // wait for scheduler
+            // first try throws an exception
+            verify(mockInfluxDB, times(1)).write(any(BatchPoints.class));
 
-        // first try throws an exception
-        verify(mockInfluxDB, times(1)).write(any(BatchPoints.class));
-
-        batchProcessor.put(batchEntry2);
-        Thread.sleep(200); // wait for scheduler
-        // without try catch the 2nd time does not occur
-        verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
+            batchProcessor.put(batchEntry2);
+            Thread.sleep(200); // wait for scheduler
+            // without try catch the 2nd time does not occur
+            verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
+        }
+        finally {
+            batchProcessor.flush();
+        }
     }
 
     @Test
@@ -49,16 +53,21 @@ public class BatchProcessorTest {
         BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(Integer.MAX_VALUE)
             .interval(1, TimeUnit.NANOSECONDS).build();
 
-        Point point = Point.measurement("cpu").field("6", "").build();
-        BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_1");
-        BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_2");
+        try {
+            Point point = Point.measurement("cpu").field("6", "").build();
+            BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_1");
+            BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_2");
 
-        batchProcessor.put(batchEntry1);
-        batchProcessor.put(batchEntry2);
+            batchProcessor.put(batchEntry1);
+            batchProcessor.put(batchEntry2);
 
-        Thread.sleep(200); // wait for scheduler
-        // same dbname with different rp should write two batchs instead of only one.
-        verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
+            Thread.sleep(200); // wait for scheduler
+            // same dbname with different rp should write two batchs instead of only one.
+            verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
+        }
+        finally {
+            batchProcessor.flush();
+        }
     }
 
     @Test
@@ -67,36 +76,39 @@ public class BatchProcessorTest {
         BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(2)
             .interval(10, TimeUnit.MINUTES).build();
 
-        Point point = Point.measurement("cpu").addField("4", "").build();
-        BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_1");
-        BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_2");
-        BatchProcessor.HttpBatchEntry batchEntry3 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_3");
+        try {
+            Point point = Point.measurement("cpu").addField("4", "").build();
+            BatchProcessor.HttpBatchEntry batchEntry1 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_1");
+            BatchProcessor.HttpBatchEntry batchEntry2 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_2");
+            BatchProcessor.HttpBatchEntry batchEntry3 = new BatchProcessor.HttpBatchEntry(point, "db1", "rp_3");
 
-        assertThat(batchProcessor.offer(batchEntry1), is(true));
-        assertThat(batchProcessor.offer(batchEntry2), is(true));
-        assertThat(batchProcessor.offer(batchEntry3), is(false));
-
-        batchProcessor.flush();
+            assertThat(batchProcessor.offer(batchEntry1), is(true));
+            assertThat(batchProcessor.offer(batchEntry2), is(true));
+            assertThat(batchProcessor.offer(batchEntry3), is(false));
+        }
+        finally {
+            batchProcessor.flush();
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testActionsIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
         BatchProcessor.builder(mockInfluxDB).actions(0)
-            .interval(1, TimeUnit.NANOSECONDS).build();
+            .interval(1, TimeUnit.NANOSECONDS).build().flush();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testIntervalIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
         BatchProcessor.builder(mockInfluxDB).actions(1)
-            .interval(0, TimeUnit.NANOSECONDS).build();
+            .interval(0, TimeUnit.NANOSECONDS).build().flush();
     }
 
     @Test(expected = NullPointerException.class)
     public void testInfluxDBIsNull() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = null;
         BatchProcessor.builder(mockInfluxDB).actions(1)
-            .interval(1, TimeUnit.NANOSECONDS).build();
+            .interval(1, TimeUnit.NANOSECONDS).build().flush();
     }
 }


### PR DESCRIPTION
Recently a change was introduced to optionally bound the actions queue in `BatchProcessor`. That's a great improvement, but the blocking semantics of `queue.put(...)` aren't always desirable.

We (@neeveresearch) wanted to attempt to enqueue a point in the batch. If the queue is full, we then wanted to simply drop the data and continue on with other more important things. Due to the blocking semantics, we ended up having to roll our own batching.

This PR introduces `InfluxDB.tryWrite(...)` methods that have similar semantics to `BlockingQueue.offer(...)` when batching is enabled: if the BatchProcessor's action queue is full, return false and leave it to the caller to determine what to do next. If batching is _not_ enabled, it's equivalent to the semantics of a normal write (albeit we return `true`).

This change should be fully backward compatible with earlier releases at the source & bytecode level. I also modified the BatchProcessorTest to clean up threads that might otherwise leak.