### PR TITLE
Added InfluxDB.flush() and consistency level can be configured for batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - Support chunking
  - Add a databaseExists method to InfluxDB interface
+ - [Issue #289] (https://github.com/influxdata/influxdb-java/issues/289) Batching enhancements: Pending asynchronous writes can be explicitly flushed via `InfluxDB.flush()`.
 
 #### Fixes
 
@@ -15,6 +16,7 @@
  - Update slf4j from 1.7.22 to 1.7.24
  - Update okhttp3 from 3.5 to 3.6
  - automatically adjust batch processor capacity [PR #282]
+ - [Issue #289] (https://github.com/influxdata/influxdb-java/issues/289) Batching enhancements: Consistency Level may be specified when batching is enabled.
 
 ## v2.5 [2016-12-05]
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -94,12 +94,22 @@ public interface InfluxDB {
   public boolean isGzipEnabled();
 
   /**
-   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory)}}
-   * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
+   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)}
+   * with a default consistency level of {@link ConsistencyLevel#QUORUM QUORUM} using
+   * {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
    *
-   * @see #enableBatch(int, int, TimeUnit, ThreadFactory)
+   * @see #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
+
+  /**
+   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)}
+   * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
+   *
+   * @see #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)
+   */
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel);
 
   /**
    * Enable batching of single Point writes to speed up writes significant. If either actions or
@@ -112,10 +122,15 @@ public interface InfluxDB {
    * @param flushDuration
    *            the time to wait at most.
    * @param flushDurationTimeUnit
+   *            the unit the flush duration is measured in.
+   * @param consistencyLevel
+   *            The write consistency level to use when writing batched points.
    * @param threadFactory
+   *            The thread factory to use when creating new threads to handle asynchronous writes.
    * @return the InfluxDB instance to be able to use it in a fluent manner.
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel,
                               final ThreadFactory threadFactory);
 
   /**
@@ -272,6 +287,14 @@ public interface InfluxDB {
    * @return true if the database exists or false if it doesn't exist
    */
   public boolean databaseExists(final String name);
+
+  /**
+   * Send any buffered points to InfluxDB. This method is synchronous and will block while all pending points are
+   * written.
+   *
+   * @throws IllegalStateException if batching is not enabled.
+   */
+  public void flush();
 
   /**
    * close thread for asynchronous batch write and UDP socket to release resources if need.

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -36,6 +36,7 @@ public class BatchProcessor {
   final int actions;
   private final TimeUnit flushIntervalUnit;
   private final int flushInterval;
+  private final InfluxDB.ConsistencyLevel consistencyLevel;
 
   /**
    * The Builder to create a BatchProcessor instance.
@@ -46,6 +47,7 @@ public class BatchProcessor {
     private int actions;
     private TimeUnit flushIntervalUnit;
     private int flushInterval;
+    private InfluxDB.ConsistencyLevel consistencyLevel;
 
     /**
      * @param threadFactory
@@ -93,6 +95,18 @@ public class BatchProcessor {
     }
 
     /**
+     * Set the consistency level writes should use.
+     *
+     * @param consistencyLevel
+     *            The consistency level.
+     * @return this Builder to use it fluent
+     */
+    public Builder consistencyLevel(final InfluxDB.ConsistencyLevel consistencyLevel) {
+      this.consistencyLevel = consistencyLevel;
+      return this;
+    }
+
+    /**
      * Create the BatchProcessor.
      *
      * @return the BatchProcessor instance.
@@ -102,9 +116,10 @@ public class BatchProcessor {
       Preconditions.checkArgument(this.actions > 0, "actions should > 0");
       Preconditions.checkArgument(this.flushInterval > 0, "flushInterval should > 0");
       Preconditions.checkNotNull(this.flushIntervalUnit, "flushIntervalUnit may not be null");
+      Preconditions.checkNotNull(this.consistencyLevel, "consistencyLevel must not be null");
       Preconditions.checkNotNull(this.threadFactory, "threadFactory may not be null");
       return new BatchProcessor(this.influxDB, this.threadFactory, this.actions, this.flushIntervalUnit,
-                                this.flushInterval);
+                                this.flushInterval, this.consistencyLevel);
     }
   }
 
@@ -164,12 +179,14 @@ public class BatchProcessor {
   }
 
   BatchProcessor(final InfluxDBImpl influxDB, final ThreadFactory threadFactory, final int actions,
-                 final TimeUnit flushIntervalUnit, final int flushInterval) {
+                 final TimeUnit flushIntervalUnit, final int flushInterval,
+                 final InfluxDB.ConsistencyLevel consistencyLevel) {
     super();
     this.influxDB = influxDB;
     this.actions = actions;
     this.flushIntervalUnit = flushIntervalUnit;
     this.flushInterval = flushInterval;
+    this.consistencyLevel = consistencyLevel;
     this.scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
         if (actions > 1 && actions < Integer.MAX_VALUE) {
         this.queue = new LinkedBlockingQueue<>(actions);
@@ -207,6 +224,7 @@ public class BatchProcessor {
             String batchKey = dbName + "_" + rp;
             if (!batchKeyToBatchPoints.containsKey(batchKey)) {
               BatchPoints batchPoints = BatchPoints.database(dbName)
+                                                   .consistency(consistencyLevel)
                                                    .retentionPolicy(rp).build();
               batchKeyToBatchPoints.put(batchKey, batchPoints);
             }
@@ -263,9 +281,15 @@ public class BatchProcessor {
    * called if no batch processing is needed anymore.
    *
    */
-  void flush() {
+  void flushAndShutdown() {
     this.write();
     this.scheduler.shutdown();
   }
 
+  /**
+   * Flush the current open writes to InfluxDB. This will block until all pending points are written.
+   */
+  void flush() {
+    this.write();
+  }
 }

--- a/src/test/java/org/influxdb/impl/BatchProcessorTest.java
+++ b/src/test/java/org/influxdb/impl/BatchProcessorTest.java
@@ -1,10 +1,12 @@
 package org.influxdb.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -13,14 +15,17 @@ import org.influxdb.InfluxDB;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class BatchProcessorTest {
 
     @Test
     public void testSchedulerExceptionHandling() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
-        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(Integer.MAX_VALUE)
-            .interval(1, TimeUnit.NANOSECONDS).build();
+        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB)
+                .actions(Integer.MAX_VALUE)
+                .consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
+                .interval(1, TimeUnit.NANOSECONDS).build();
 
         doThrow(new RuntimeException()).when(mockInfluxDB).write(any(BatchPoints.class));
 
@@ -43,7 +48,9 @@ public class BatchProcessorTest {
     @Test
     public void testBatchWriteWithDifferenctRp() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
-        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB).actions(Integer.MAX_VALUE)
+        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB)
+            .actions(Integer.MAX_VALUE)
+            .consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
             .interval(1, TimeUnit.NANOSECONDS).build();
 
         Point point = Point.measurement("cpu").field("6", "").build();
@@ -58,24 +65,83 @@ public class BatchProcessorTest {
         verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
     }
 
+    @Test
+    public void testConsistencyLevelIsHonored() {
+        InfluxDB.ConsistencyLevel desiredConsistencyLevel = InfluxDB.ConsistencyLevel.QUORUM;
+
+        InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
+        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB)
+                .actions(Integer.MAX_VALUE)
+                .consistencyLevel(desiredConsistencyLevel)
+                .interval(1, TimeUnit.DAYS).build();
+
+        Point point = Point.measurement("test").addField("region", "a").build();
+        BatchProcessor.HttpBatchEntry httpBatchEntry = new BatchProcessor.HttpBatchEntry(point, "http", "http-rp");
+
+        batchProcessor.put(httpBatchEntry);
+
+        batchProcessor.flush();
+
+        ArgumentCaptor<BatchPoints> batchPoints = ArgumentCaptor.forClass(BatchPoints.class);
+
+        verify(mockInfluxDB, times(1)).write(batchPoints.capture());
+
+        assertThat(batchPoints.getAllValues()).hasSize(1);
+        assertThat(batchPoints.getValue().getConsistency()).isEqualTo(desiredConsistencyLevel);
+    }
+
+    @Test
+    public void testFlushWritesBufferedPointsAndDoesNotShutdownScheduler() throws InterruptedException {
+        InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
+        BatchProcessor batchProcessor = BatchProcessor.builder(mockInfluxDB)
+                .actions(Integer.MAX_VALUE)
+                .consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
+                .interval(1, TimeUnit.NANOSECONDS).build();
+
+        Point point = Point.measurement("test").addField("region", "a").build();
+        BatchProcessor.HttpBatchEntry httpBatchEntry = new BatchProcessor.HttpBatchEntry(point, "http", "http-rp");
+
+        batchProcessor.put(httpBatchEntry);
+        Thread.sleep(100); // wait for scheduler
+        // Our put should have been written
+        verify(mockInfluxDB).write(any(BatchPoints.class));
+
+        // Force a flush which should not stop the scheduler
+        batchProcessor.flush();
+
+        batchProcessor.put(httpBatchEntry);
+        Thread.sleep(100); // wait for scheduler
+        // Our second put should have been written if the scheduler is still running
+        verify(mockInfluxDB, times(2)).write(any(BatchPoints.class));
+
+        verifyNoMoreInteractions(mockInfluxDB);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testActionsIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
-        BatchProcessor.builder(mockInfluxDB).actions(0)
+        BatchProcessor.builder(mockInfluxDB).actions(0).consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
             .interval(1, TimeUnit.NANOSECONDS).build();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testIntervalIsZero() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
-        BatchProcessor.builder(mockInfluxDB).actions(1)
+        BatchProcessor.builder(mockInfluxDB).actions(1).consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
             .interval(0, TimeUnit.NANOSECONDS).build();
     }
     
     @Test(expected = NullPointerException.class)
     public void testInfluxDBIsNull() throws InterruptedException, IOException {
         InfluxDB mockInfluxDB = null;
-        BatchProcessor.builder(mockInfluxDB).actions(1)
+        BatchProcessor.builder(mockInfluxDB).actions(1).consistencyLevel(InfluxDB.ConsistencyLevel.ONE)
             .interval(1, TimeUnit.NANOSECONDS).build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConsistencyLevelIsNull() {
+        InfluxDB mockInfluxDB = mock(InfluxDBImpl.class);
+        BatchProcessor.builder(mockInfluxDB).actions(1).consistencyLevel(null)
+                .interval(1, TimeUnit.NANOSECONDS).build();
     }
 }


### PR DESCRIPTION
This addresses a couple requested enhancements described in #289. Specifically:

1. `InfluxDB.flush()` was introduced as a mechanism for flushing the underlying `BatchProcessor` without shutting it down. It's a step toward being able to guarantee all asynchronously queued points are delivered at a given time when operating in batch mode. This doesn't change the failure handling for `BatchProcessor.write()` so records may still be silently dropped as a result of flushing.
2. The consistently level can be configured for asynchronous writes. The default was not changed and is still `ONE`. It can be explicitly set via `InfluxDB.enableBatch(int, int, TimeUnit, ConsistencyLevel)`.
