### PR TITLE
Allow Point.Builder to be reused for unique value, but shared tags

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -208,7 +208,7 @@ public class Point {
           .checkArgument(this.fields.size() > 0,
           "Point must have at least one field specified.");
       Point point = new Point();
-      point.setFields(this.fields);
+      point.setFields(new TreeMap<String, Object>(this.fields));
       point.setMeasurement(this.measurement);
       if (this.time != null) {
           point.setTime(this.time);
@@ -217,7 +217,7 @@ public class Point {
           point.setTime(System.currentTimeMillis());
           point.setPrecision(TimeUnit.MILLISECONDS);
       }
-      point.setTags(this.tags);
+      point.setTags(new TreeMap<String, String>(this.tags));
       return point;
     }
   }


### PR DESCRIPTION
I have a case where I want to build a whole bunch of points (from existing data in other formats), and thus I want to use the same tags over and over.  I tried to do this with the ``Point.Builder``, but discovered that it passes the mutable maps of fields and tags directly to the ``Point`` it builds.  
