### PR TITLE
Write consistency can be set for batching mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - Update slf4j from 1.7.22 to 1.7.24
  - Update okhttp3 from 3.5 to 3.6
  - automatically adjust batch processor capacity [PR #282]
+ - [Issue #289] (https://github.com/influxdata/influxdb-java/issues/289) Batching enhancements: Consistency Level may be specified when batching is enabled.
 
 ## v2.5 [2016-12-05]
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -94,12 +94,22 @@ public interface InfluxDB {
   public boolean isGzipEnabled();
 
   /**
-   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory)}}
-   * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
+   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)}
+   * with a default consistency level of {@link ConsistencyLevel#ONE ONE} using
+   * {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
    *
-   * @see #enableBatch(int, int, TimeUnit, ThreadFactory)
+   * @see #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
+
+  /**
+   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)}
+   * using {@linkplain java.util.concurrent.Executors#defaultThreadFactory() default thread factory}.
+   *
+   * @see #enableBatch(int, int, TimeUnit, ConsistencyLevel, ThreadFactory)
+   */
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel);
 
   /**
    * Enable batching of single Point writes to speed up writes significant. If either actions or
@@ -112,10 +122,15 @@ public interface InfluxDB {
    * @param flushDuration
    *            the time to wait at most.
    * @param flushDurationTimeUnit
+   *            the unit the flush duration is measured in.
+   * @param consistencyLevel
+   *            The write consistency level to use when writing batched points.
    * @param threadFactory
+   *            The thread factory to use when creating new threads to handle asynchronous writes.
    * @return the InfluxDB instance to be able to use it in a fluent manner.
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel,
                               final ThreadFactory threadFactory);
 
   /**

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -150,16 +150,32 @@ public class InfluxDBImpl implements InfluxDB {
     return this.gzipRequestInterceptor.isEnabled();
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public InfluxDB enableBatch(final int actions, final int flushDuration,
                               final TimeUnit flushDurationTimeUnit) {
-    enableBatch(actions, flushDuration, flushDurationTimeUnit, Executors.defaultThreadFactory());
+    enableBatch(actions, flushDuration, flushDurationTimeUnit, ConsistencyLevel.ONE);
     return this;
   }
 
+  /**
+   * {@inheritDoc}
+   */
   @Override
-  public InfluxDB enableBatch(final int actions, final int flushDuration,
-                              final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory) {
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel) {
+    enableBatch(actions, flushDuration, flushDurationTimeUnit, consistencyLevel, Executors.defaultThreadFactory());
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ConsistencyLevel consistencyLevel, final ThreadFactory threadFactory) {
     if (this.batchEnabled.get()) {
       throw new IllegalStateException("BatchProcessing is already enabled.");
     }
@@ -167,6 +183,7 @@ public class InfluxDBImpl implements InfluxDB {
         .builder(this)
         .actions(actions)
         .interval(flushDuration, flushDurationTimeUnit)
+        .consistencyLevel(consistencyLevel)
         .threadFactory(threadFactory)
         .build();
     this.batchEnabled.set(true);

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -414,12 +414,12 @@ public class InfluxDBTest {
 	}
 	
 	/**
-	 * Test the implementation of {@link InfluxDB#enableBatch(int, int, TimeUnit, ThreadFactory)}.
+	 * Test the implementation of {@link InfluxDB#enableBatch(int, int, TimeUnit, InfluxDB.ConsistencyLevel, ThreadFactory)}.
 	 */
 	@Test
 	public void testBatchEnabledWithThreadFactory() {
 		final String threadName = "async_influxdb_write";
-		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS, new ThreadFactory() {
+		this.influxDB.enableBatch(1, 1, TimeUnit.SECONDS, InfluxDB.ConsistencyLevel.ONE, new ThreadFactory() {
 			
 			@Override
 			public Thread newThread(Runnable r) {


### PR DESCRIPTION
The consistently level can be configured for asynchronous writes. The default was not changed and is still ONE. It can be explicitly set via InfluxDB.enableBatch(int, int, TimeUnit, ConsistencyLevel). See #289 for more context.