### PR TITLE
Improve performance of TimeUtil

### DIFF
--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -9,15 +9,13 @@ import java.util.concurrent.TimeUnit;
  * Utils for time related methods.
  *
  * @author stefan.majer [at] gmail.com
- *
  */
 public enum TimeUtil {
     INSTANCE;
 
-    private static final ThreadLocal<SimpleDateFormat> formatter = new ThreadLocal<SimpleDateFormat>(){
+    private static final ThreadLocal<SimpleDateFormat> FORMATTER = new ThreadLocal<SimpleDateFormat>() {
         @Override
-        protected SimpleDateFormat initialValue()
-        {
+        protected SimpleDateFormat initialValue() {
             SimpleDateFormat dateDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
             dateDF.setTimeZone(TimeZone.getTimeZone("UTC"));
             return dateDF;
@@ -67,7 +65,7 @@ public enum TimeUtil {
      * @return influxdb compatible date-tome string
      */
     public static String toInfluxDBTimeFormat(final long time) {
-        return formatter.get().format(time);
+        return FORMATTER.get().format(time);
     }
 
     /**
@@ -79,7 +77,7 @@ public enum TimeUtil {
      */
     public static long fromInfluxDBTimeFormat(final String time) {
         try {
-            return formatter.get().parse(time).getTime();
+            return FORMATTER.get().parse(time).getTime();
         } catch (Exception e) {
             throw new RuntimeException("unexpected date format", e);
         }


### PR DESCRIPTION
TimeUtil creates 2 SimpleDateFormatter's (one for the date part and one for the time part) for each operation (toInfluxDBTimeFormat and fromInfluxDBTimeFormat).
This is suboptimal as creating a SimpleDateFormat is expensive (but ensures thread safety) and also force 2 operations.

Changing the SimpleDateFormat format to "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" allows that only one SimpleDateFormatter can be used to parse/format the influxDBTimeFormat.

In order to reduce the number of instanciations while making sure it remains thread safe, I have introduced a ThreadLocale storing one SimpleDateFormatter object per thread. So we can use those objects without any synchronization.