### PR TITLE
Add support for seconds only formatted time.

### DIFF
--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -13,10 +13,19 @@ import java.util.concurrent.TimeUnit;
 public enum TimeUtil {
     INSTANCE;
 
-    private static final ThreadLocal<SimpleDateFormat> FORMATTER = new ThreadLocal<SimpleDateFormat>() {
+    private static final ThreadLocal<SimpleDateFormat> FORMATTER_MILLIS = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
             SimpleDateFormat dateDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            dateDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return dateDF;
+        }
+    };
+
+    private static final ThreadLocal<SimpleDateFormat> FORMATTER_SECONDS = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat dateDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
             dateDF.setTimeZone(TimeZone.getTimeZone("UTC"));
             return dateDF;
         }
@@ -65,19 +74,22 @@ public enum TimeUtil {
      * @return influxdb compatible date-tome string
      */
     public static String toInfluxDBTimeFormat(final long time) {
-        return FORMATTER.get().format(time);
+        return FORMATTER_MILLIS.get().format(time);
     }
 
     /**
      * convert an influxdb timestamp used by influxdb to unix epoch time.
-     * influxdb time format example: 2016-10-31T06:52:20.020Z
+     * influxdb time format example: 2016-10-31T06:52:20.020Z or 2016-10-31T06:52:20Z
      *
      * @param time timestamp to use, in influxdb datetime format
      * @return time in unix epoch time
      */
     public static long fromInfluxDBTimeFormat(final String time) {
         try {
-            return FORMATTER.get().parse(time).getTime();
+            if (time.length() == 20) {
+                return FORMATTER_SECONDS.get().parse(time).getTime();
+            }
+            return FORMATTER_MILLIS.get().parse(time).getTime();
         } catch (Exception e) {
             throw new RuntimeException("unexpected date format", e);
         }

--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -39,6 +39,8 @@ public enum TimeUtil {
       TimeUnit.MICROSECONDS,
       TimeUnit.NANOSECONDS);
 
+    public static final int TIME_IN_SECOND_LENGTH = 20;
+
   /**
    * Convert from a TimeUnit to a influxDB timeunit String.
    *
@@ -87,7 +89,7 @@ public enum TimeUtil {
      */
     public static long fromInfluxDBTimeFormat(final String time) {
         try {
-            if (time.length() == 20) {
+            if (time.length() == TIME_IN_SECOND_LENGTH) {
                 return FORMATTER_SECONDS.get().parse(time).getTime();
             }
             return FORMATTER_MILLIS.get().parse(time).getTime();

--- a/src/test/java/org/influxdb/impl/TimeUtilTest.java
+++ b/src/test/java/org/influxdb/impl/TimeUtilTest.java
@@ -17,5 +17,7 @@ public class TimeUtilTest {
     public void fromInfluxDBTimeFormatTest() throws Exception {
         assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T06:52:20.020Z"), is(equalTo(1477896740020L)));
         assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T16:52:20.005Z"), is(equalTo(1477932740005L)));
+        assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T16:52:20Z"), is(equalTo(1477932740000L)));
+        assertThat(TimeUtil.fromInfluxDBTimeFormat("2016-10-31T06:52:20Z"), is(equalTo(1477896740000L)));
     }
 }


### PR DESCRIPTION
While parsing query results I received a time that was formatted like '2017-02-05T11:00:00Z'. As you can see no millis where provided, the query was something like 
    SELECT time, data FROM myTable WHERE time >= '2017-01-01T00:00:00.000Z'
I used the Query object and retrieved the Series object
 QueryResult qr = db.query(q);
        for (QueryResult.Result r : qr.getResults()) {
            for (QueryResult.Series s : r.getSeries()) {
                for (List<Object> v : s.getValues()) {
                   //...
                  String myTimestamp = (String) v.get(timePos);

So I adapted the TimeUtil to support this format by detecting that the length is 20 insteead of 24 (as the ".xyz" is not provided)
