### PR TITLE
Added test for multiple backslashes

### DIFF
--- a/src/test/java/org/influxdb/TicketTest.java
+++ b/src/test/java/org/influxdb/TicketTest.java
@@ -1,6 +1,8 @@
+
 package org.influxdb;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdb.InfluxDB.LogLevel;


### PR DESCRIPTION
If I attempt to insert backslashes in a field I get bad timestamp errors: 

If I use the following code: 
 ```
 Point point1 = Point
                            .measurement("TestSlash")
                            .time(rundate1Sec, TimeUnit.SECONDS)
                            .tag("precision", "Second")                       
                            .addField("MultipleSlash" ,  "echo \\\".ll 12.0i\\\";")                            
                            .build(); 
        
         currentPoints.point(point1); 
           
         Influxdb.write(currentPoints.build());

```
I get the following error:
`{"error":"unable to parse 'TestSlash,precision=Second MultipleSlash=\"echo \\\\\".ll 12.0i\\\\\";\" 1490273411000000000': bad timestamp"}
`
This test proves the latest version of the code has already fixed the issue