### PR TITLE
Shading google guava to avoid dependency problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/dependency-reduced-pom.xml
 target/
 *~
 .classpath

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,48 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<minimizeJar>true</minimizeJar>
+					<artifactSet>
+						<includes>
+							<include>com.google.guava:guava</include>
+						</includes>
+					</artifactSet>
+					<relocations>
+						<relocation>
+							<pattern>com.google.common</pattern>
+							<shadedPattern>org.influxdb.com.google.guava</shadedPattern>
+						</relocation>
+					</relocations>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>META-INF/license/**</exclude>
+								<exclude>META-INF/*</exclude>
+								<exclude>META-INF/maven/**</exclude>
+								<exclude>LICENSE</exclude>
+								<exclude>NOTICE</exclude>
+								<exclude>/*.txt</exclude>
+								<exclude>build.properties</exclude>
+							</excludes>
+						</filter>
+					</filters>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 	<dependencies>


### PR DESCRIPTION
Like they did in elastic search and many other libraries, I've shaded google guava dependency, because I have conflicts of guava's version.