### PR TITLE
Add a query() method that returns an Iterator<QueryResult>

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -1,5 +1,6 @@
 package org.influxdb;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -217,6 +218,17 @@ public interface InfluxDB {
    * @return a List of Series which matched the query.
    */
   public QueryResult query(final Query query);
+
+  /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @return an Iterator of a list of Series which matched the query.
+   */
+  public Iterator<QueryResult> query(Query query, int chunkSize);
 
   /**
    * Execute a streaming query against a database.

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -253,6 +253,18 @@ public interface InfluxDB {
   public QueryResult query(final Query query, TimeUnit timeUnit);
 
   /**
+   * Execute a query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param timeUnit the time unit of the results.
+   * @return an Iterator of a list of Series which matched the query.
+   */
+  public Iterator<QueryResult> query(final Query query, int chunkSize, TimeUnit timeUnit);
+
+  /**
    * Create a new Database.
    *
    * @param name

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -340,13 +340,18 @@ public class InfluxDBImpl implements InfluxDB {
   }
 
   @Override
-  public Iterator<QueryResult> query(final Query query, final int chunkSize) {
+  public Iterator<QueryResult> query(Query query, int chunkSize) {
+    return query(query, chunkSize, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public Iterator<QueryResult> query(final Query query, final int chunkSize, TimeUnit timeUnit) {
     if (version().startsWith("0.") || version().startsWith("1.0")) {
         throw new RuntimeException("chunking not supported");
     }
 
-    Call<ResponseBody> call = this.influxDBService.query(this.username, this.password,
-            query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
+    Call<ResponseBody> call = this.influxDBService.query(this.username,
+            this.password, query.getDatabase(), TimeUtil.toTimePrecision(timeUnit), query.getCommandWithUrlEncoded(), chunkSize);
 
     try {
         Response<ResponseBody> response = call.execute();
@@ -403,8 +408,7 @@ public class InfluxDBImpl implements InfluxDB {
    * {@inheritDoc}
    */
   @Override
-    public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
-
+  public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
         if (version().startsWith("0.") || version().startsWith("1.0")) {
             throw new RuntimeException("chunking not supported");
         }

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -68,4 +68,10 @@ interface InfluxDBService {
   public Call<ResponseBody> query(@Query(U) String username,
       @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query,
       @Query(CHUNK_SIZE) int chunkSize);
+  @Streaming
+  @GET("/query?chunked=true")
+  public Call<ResponseBody> query(@Query(U) String username,
+      @Query(P) String password, @Query(DB) String db, @Query(EPOCH) String epoch, @Query(value = Q, encoded = true) String query,
+      @Query(CHUNK_SIZE) int chunkSize);
+
 }


### PR DESCRIPTION
New query() methods as mentioned in https://github.com/influxdata/influxdb-java/issues/308

```java
  public Iterator<QueryResult> query(Query query, int chunkSize);
  public Iterator<QueryResult> query(final Query query, int chunkSize, TimeUnit timeUnit);
```