### PR TITLE
Add exception callback to handle async errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,16 @@ Query query = new Query("SELECT idle FROM cpu", dbName);
 influxDB.query(query);
 influxDB.deleteDatabase(dbName);
 ```
-Note that the batching functionality creates an internal thread pool that needs to be shutdown explicitly as part of a gracefull application shut-down, or the application will not shut down properly. To do so simply call: ```influxDB.close()```
+Note that the batching functionality creates an internal thread pool that needs to be shutdown explicitly as part of a graceful application shut-down, or the application will not shut down properly. To do so simply call: ```influxDB.close()```
+
+Also note that any errors that happen during the batch flush won't leak into the caller of the `write` method. By default, any kind of errors will be just logged with "SEVERE" level.
+
+If you need to be notified and do some custom logic when such asynchronous errors happen, you can add an error handler with a `Consumer<Throwable>` using the overloaded `enableBatch` method:
+ 
+```java
+// Flush every 2000 Points, at least every 100ms
+influxDB.enableBatch(2000, 100, TimeUnit.MILLISECONDS, Executors.defaultThreadFactory(), (throwable) -> { /* custom error handling here */ });
+```
 
 ### Advanced Usages:
 

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -102,7 +102,8 @@ public interface InfluxDB {
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
 
   /**
-   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory, Consumer<Throwable>)}
+   * Enable batching of single Point writes as
+   * {@link #enableBatch(int, int, TimeUnit, ThreadFactory, Consumer<Throwable>)}
    * using with a exceptionHandler that does nothing.
    *
    * @see #enableBatch(int, int, TimeUnit, ThreadFactory, Consumer<Throwable>)

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -102,6 +102,15 @@ public interface InfluxDB {
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit);
 
   /**
+   * Enable batching of single Point writes as {@link #enableBatch(int, int, TimeUnit, ThreadFactory, Consumer<Throwable>)}
+   * using with a exceptionHandler that does nothing.
+   *
+   * @see #enableBatch(int, int, TimeUnit, ThreadFactory, Consumer<Throwable>)
+   */
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ThreadFactory threadFactory);
+
+  /**
    * Enable batching of single Point writes to speed up writes significant. If either actions or
    * flushDurations is reached first, a batch write is issued.
    * Note that batch processing needs to be explicitly stopped before the application is shutdown.
@@ -113,10 +122,12 @@ public interface InfluxDB {
    *            the time to wait at most.
    * @param flushDurationTimeUnit
    * @param threadFactory
+   * @param exceptionHandler
+   *            a consumer function to handle asynchronous errors
    * @return the InfluxDB instance to be able to use it in a fluent manner.
    */
   public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
-                              final ThreadFactory threadFactory);
+                              final ThreadFactory threadFactory, final Consumer<Throwable> exceptionHandler);
 
   /**
    * Disable Batching.

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -103,7 +103,7 @@ public class BatchProcessor {
      *
      * @return this Builder to use it fluent
      */
-    public Builder exceptionHandler(Consumer<Throwable> handler) {
+    public Builder exceptionHandler(final Consumer<Throwable> handler) {
       this.exceptionHandler = handler;
       return this;
     }
@@ -181,7 +181,7 @@ public class BatchProcessor {
   }
 
   BatchProcessor(final InfluxDBImpl influxDB, final ThreadFactory threadFactory, final int actions,
-                 final TimeUnit flushIntervalUnit, final int flushInterval, Consumer<Throwable> exceptionHandler) {
+                 final TimeUnit flushIntervalUnit, final int flushInterval, final Consumer<Throwable> exceptionHandler) {
     super();
     this.influxDB = influxDB;
     this.actions = actions;

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -48,7 +48,7 @@ public class BatchProcessor {
     private int actions;
     private TimeUnit flushIntervalUnit;
     private int flushInterval;
-    private Consumer<Throwable> exceptionHandler = throwable -> {};
+    private Consumer<Throwable> exceptionHandler = throwable -> { };
 
     /**
      * @param threadFactory
@@ -96,7 +96,7 @@ public class BatchProcessor {
     }
 
     /**
-     * A callback to be used when an error occurs during a batchwrite
+     * A callback to be used when an error occurs during a batchwrite.
      *
      * @param handler
      *            the handler
@@ -181,7 +181,8 @@ public class BatchProcessor {
   }
 
   BatchProcessor(final InfluxDBImpl influxDB, final ThreadFactory threadFactory, final int actions,
-                 final TimeUnit flushIntervalUnit, final int flushInterval, final Consumer<Throwable> exceptionHandler) {
+                 final TimeUnit flushIntervalUnit, final int flushInterval,
+                 final Consumer<Throwable> exceptionHandler) {
     super();
     this.influxDB = influxDB;
     this.actions = actions;

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -165,7 +165,8 @@ public class InfluxDBImpl implements InfluxDB {
   }
 
   @Override
-  public InfluxDB enableBatch(int actions, int flushDuration, TimeUnit flushDurationTimeUnit, ThreadFactory threadFactory, Consumer<Throwable> exceptionHandler) {
+  public InfluxDB enableBatch(final int actions, final int flushDuration, final TimeUnit flushDurationTimeUnit,
+                              final ThreadFactory threadFactory, final Consumer<Throwable> exceptionHandler) {
     if (this.batchEnabled.get()) {
       throw new IllegalStateException("BatchProcessing is already enabled.");
     }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -160,15 +160,21 @@ public class InfluxDBImpl implements InfluxDB {
   @Override
   public InfluxDB enableBatch(final int actions, final int flushDuration,
                               final TimeUnit flushDurationTimeUnit, final ThreadFactory threadFactory) {
+    enableBatch(actions, flushDuration, flushDurationTimeUnit, threadFactory, (throwable) -> { });
+    return this;
+  }
+
+  @Override
+  public InfluxDB enableBatch(int actions, int flushDuration, TimeUnit flushDurationTimeUnit, ThreadFactory threadFactory, Consumer<Throwable> exceptionHandler) {
     if (this.batchEnabled.get()) {
       throw new IllegalStateException("BatchProcessing is already enabled.");
     }
     this.batchProcessor = BatchProcessor
-        .builder(this)
-        .actions(actions)
-        .interval(flushDuration, flushDurationTimeUnit)
-        .threadFactory(threadFactory)
-        .build();
+            .builder(this)
+            .actions(actions)
+            .interval(flushDuration, flushDurationTimeUnit)
+            .threadFactory(threadFactory)
+            .build();
     this.batchEnabled.set(true);
     return this;
   }


### PR DESCRIPTION
This enables the client to do something (other than logging) if a problem happens asynchronously. In our use case, we want to send the error to honeybadger.io to be notified of influxdb issues.