### PR TITLE
influxdb-java-182 Allow write precision of TimeUnit other than Nanoseconds

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -184,6 +184,16 @@ public interface InfluxDB {
                     final ConsistencyLevel consistency, final String records);
 
   /**
+   * Write a set of Points to the influxdb database with the string records.
+   *
+   * {@linkplain "https://github.com/influxdb/influxdb/pull/2696"}
+   *
+   * @param records
+   */
+  public void write(final String database, final String retentionPolicy,
+          final ConsistencyLevel consistency, final TimeUnit precision, final String records);
+
+  /**
    * Write a set of Points to the influxdb database with the list of string records.
    *
    * {@linkplain "https://github.com/influxdb/influxdb/pull/2696"}
@@ -192,6 +202,16 @@ public interface InfluxDB {
    */
   public void write(final String database, final String retentionPolicy,
                     final ConsistencyLevel consistency, final List<String> records);
+
+  /**
+   * Write a set of Points to the influxdb database with the list of string records.
+   *
+   * {@linkplain "https://github.com/influxdb/influxdb/pull/2696"}
+   *
+   * @param records
+   */
+  public void write(final String database, final String retentionPolicy,
+          final ConsistencyLevel consistency, final TimeUnit precision, final List<String> records);
 
   /**
    * Write a set of Points to the influxdb database with the string records through UDP.

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -323,6 +323,20 @@ public class Point {
     return sb.toString();
   }
 
+  /**
+   * Calculate the lineprotocol entry for a single point, using a specific {@link TimeUnit} for the timestamp
+   * @param precision the time precision unit for this point
+   * @return the String without newLine
+   */
+  public String lineProtocol(final TimeUnit precision) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(KEY_ESCAPER.escape(this.measurement));
+    sb.append(concatenatedTags());
+    sb.append(concatenateFields());
+    sb.append(formatedTime(precision));
+    return sb.toString();
+  }
+
   private StringBuilder concatenatedTags() {
     final StringBuilder sb = new StringBuilder();
     for (Entry<String, String> tag : this.tags.entrySet()) {
@@ -377,6 +391,12 @@ public class Point {
   private StringBuilder formatedTime() {
     final StringBuilder sb = new StringBuilder();
     sb.append(" ").append(TimeUnit.NANOSECONDS.convert(this.time, this.precision));
+    return sb;
+  }
+
+  private StringBuilder formatedTime(TimeUnit precision) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append(" ").append(precision.convert(this.time, this.precision));
     return sb;
   }
 

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -259,30 +259,45 @@ public class InfluxDBImpl implements InfluxDB {
         this.password,
         batchPoints.getDatabase(),
         batchPoints.getRetentionPolicy(),
-        TimeUtil.toTimePrecision(TimeUnit.NANOSECONDS),
+        TimeUtil.toTimePrecision(batchPoints.getPrecision()),
         batchPoints.getConsistency().value(),
         lineProtocol));
+  }
+
+
+  @Override
+  public void write(String database, String retentionPolicy, ConsistencyLevel consistency,
+          TimeUnit precision, String records) {
+    execute(this.influxDBService.writePoints(
+            this.username,
+            this.password,
+            database,
+            retentionPolicy,
+            TimeUtil.toTimePrecision(precision),
+            consistency.value(),
+            RequestBody.create(MEDIA_TYPE_STRING, records)));
   }
 
   @Override
   public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency,
       final String records) {
-    execute(this.influxDBService.writePoints(
-        this.username,
-        this.password,
-        database,
-        retentionPolicy,
-        TimeUtil.toTimePrecision(TimeUnit.NANOSECONDS),
-        consistency.value(),
-        RequestBody.create(MEDIA_TYPE_STRING, records)));
+    write(database, retentionPolicy, consistency, TimeUnit.NANOSECONDS, records);
   }
 
   @Override
   public void write(final String database, final String retentionPolicy, final ConsistencyLevel consistency,
       final List<String> records) {
-    final String joinedRecords = Joiner.on("\n").join(records);
-    write(database, retentionPolicy, consistency, joinedRecords);
+    write(database, retentionPolicy, consistency, TimeUnit.NANOSECONDS, records);
   }
+
+
+  @Override
+  public void write(String database, String retentionPolicy, ConsistencyLevel consistency,
+          TimeUnit precision, List<String> records) {
+    final String joinedRecords = Joiner.on("\n").join(records);
+    write(database, retentionPolicy, consistency, precision, joinedRecords);
+  }
+
 
   /**
    * {@inheritDoc}

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -17,284 +18,397 @@ import com.google.common.collect.Maps;
  * Test for the Point DTO.
  *
  * @author stefan.majer [at] gmail.com
- *
  */
 public class PointTest {
 
-	/**
-	 * Test that lineprotocol is conformant to:
-	 * 
-	 * https://github.com/influxdb/influxdb/blob/master/tsdb/README.md
-	 *
-	 */
-	@Test
-	public void lineProtocol() {
-		Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1");
+    /**
+     * Test that lineprotocol is conformant to:
+     * <p>
+     * https://github.com/influxdb/influxdb/blob/master/tsdb/README.md
+     */
+    @Test
+    public void lineProtocol() {
+        Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1");
 
-		point = Point.measurement("test,1").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test\\,1 a=1.0 1");
+        point = Point.measurement("test,1").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test\\,1 a=1.0 1");
 
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A").build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\" 1");
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A").build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\" 1");
 
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A\"B").build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\" 1");
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A\"B").build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\" 1");
 
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A\"B\"C").build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\\\"C\" 1");
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A\"B\"C").build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\\\"C\" 1");
 
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A B C").build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A B C\" 1");
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", "A B C").build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A B C\" 1");
 
-		point = Point
-				.measurement("test")
-				.time(1, TimeUnit.NANOSECONDS)
-				.addField("a", "A\"B")
-				.addField("b", "D E \"F")
-				.build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\",b=\"D E \\\"F\" 1");
+        point = Point
+                .measurement("test")
+                .time(1, TimeUnit.NANOSECONDS)
+                .addField("a", "A\"B")
+                .addField("b", "D E \"F")
+                .build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=\"A\\\"B\",b=\"D E \\\"F\" 1");
 
-		//Integer type
-		point = Point.measurement("inttest").time(1, TimeUnit.NANOSECONDS).addField("a", (Integer)1).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("inttest a=1i 1");
+        //Integer type
+        point = Point.measurement("inttest").time(1, TimeUnit.NANOSECONDS).addField("a", (Integer) 1).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("inttest a=1i 1");
 
-		point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", (Integer)1).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
+        point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", (Integer) 1).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
 
-		point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", 1L).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
+        point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", 1L).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=1i 1");
 
-		point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", BigInteger.valueOf(100)).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=100i 1");
-	}
+        point = Point.measurement("inttest,1").time(1, TimeUnit.NANOSECONDS).addField("a", BigInteger.valueOf(100))
+                .build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("inttest\\,1 a=100i 1");
+    }
 
-	/**
-	 * Test for ticket #44
-	 */
-	@Test
-	public void testTicket44() {
-		Point point = Point.measurement("test").time(1, TimeUnit.MICROSECONDS).addField("a", 1.0).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1000");
+    /**
+     * Test for ticket #44
+     */
+    @Test
+    public void testTicket44() {
+        Point point = Point.measurement("test").time(1, TimeUnit.MICROSECONDS).addField("a", 1.0).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1000");
 
-		point = Point.measurement("test").time(1, TimeUnit.MILLISECONDS).addField("a", 1.0).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1000000");
+        point = Point.measurement("test").time(1, TimeUnit.MILLISECONDS).addField("a", 1.0).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1000000");
 
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
-		BatchPoints batchPoints = BatchPoints.database("db").point(point).build();
-		assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1\n");
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", 1.0).build();
+        BatchPoints batchPoints = BatchPoints.database("db").point(point).build();
+        assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1\n");
 
-		point = Point.measurement("test").time(1, TimeUnit.MICROSECONDS).addField("a", 1.0).build();
-		batchPoints = BatchPoints.database("db").point(point).build();
-		assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000\n");
+        point = Point.measurement("test").time(1, TimeUnit.MICROSECONDS).addField("a", 1.0).build();
+        batchPoints = BatchPoints.database("db").point(point).build();
+        assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000\n");
 
-		point = Point.measurement("test").time(1, TimeUnit.MILLISECONDS).addField("a", 1.0).build();
-		batchPoints = BatchPoints.database("db").point(point).build();
-		assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000000\n");
+        point = Point.measurement("test").time(1, TimeUnit.MILLISECONDS).addField("a", 1.0).build();
+        batchPoints = BatchPoints.database("db").point(point).build();
+        assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000000\n");
 
-		point = Point.measurement("test").addField("a", 1.0).time(1, TimeUnit.MILLISECONDS).build();
-		batchPoints = BatchPoints.database("db").build();
-		batchPoints = batchPoints.point(point);
-		assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000000\n");
+        point = Point.measurement("test").addField("a", 1.0).time(1, TimeUnit.MILLISECONDS).build();
+        batchPoints = BatchPoints.database("db").build();
+        batchPoints = batchPoints.point(point);
+        assertThat(batchPoints.lineProtocol()).asString().isEqualTo("test a=1.0 1000000\n");
 
-	}
+    }
 
-	/**
-	 * Test for ticket #54
-	 */
-	@Test
-	public void testTicket54() {
-		Byte byteNumber = 100;
-		Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", byteNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100i 1");
+    /**
+     * Test for ticket #54
+     */
+    @Test
+    public void testTicket54() {
+        Byte byteNumber = 100;
+        Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", byteNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100i 1");
 
-		int intNumber = 100000000;
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", intNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
+        int intNumber = 100000000;
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", intNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
 
-		Integer integerNumber = 100000000;
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", integerNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
+        Integer integerNumber = 100000000;
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", integerNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
 
-		AtomicInteger atomicIntegerNumber = new AtomicInteger(100000000);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", atomicIntegerNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
+        AtomicInteger atomicIntegerNumber = new AtomicInteger(100000000);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", atomicIntegerNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
 
-		Long longNumber = 1000000000000000000L;
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", longNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=1000000000000000000i 1");
+        Long longNumber = 1000000000000000000L;
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", longNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=1000000000000000000i 1");
 
-		AtomicLong atomicLongNumber = new AtomicLong(1000000000000000000L);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", atomicLongNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=1000000000000000000i 1");
+        AtomicLong atomicLongNumber = new AtomicLong(1000000000000000000L);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", atomicLongNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=1000000000000000000i 1");
 
-		BigInteger bigIntegerNumber = BigInteger.valueOf(100000000);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", bigIntegerNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
+        BigInteger bigIntegerNumber = BigInteger.valueOf(100000000);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", bigIntegerNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000i 1");
 
-		Double doubleNumber = Double.valueOf(100000000.0001);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", doubleNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000.0001 1");
+        Double doubleNumber = Double.valueOf(100000000.0001);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", doubleNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000.0001 1");
 
-		Float floatNumber = Float.valueOf(0.1f);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", floatNumber).build();
-		assertThat(point.lineProtocol()).asString().startsWith("test a=0.10");
+        Float floatNumber = Float.valueOf(0.1f);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", floatNumber).build();
+        assertThat(point.lineProtocol()).asString().startsWith("test a=0.10");
 
-		BigDecimal bigDecimalNumber = BigDecimal.valueOf(100000000.00000001);
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", bigDecimalNumber).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000.00000001 1");
-	}
-	
-	@Test
-	public void testEscapingOfKeysAndValues() {
-		// Test escaping of spaces
-		Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar baz").addField( "a", 1.0 ).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\ baz a=1.0 1");
- 
-		// Test escaping of commas
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar,baz").addField( "a", 1.0 ).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\,baz a=1.0 1");
+        BigDecimal bigDecimalNumber = BigDecimal.valueOf(100000000.00000001);
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).addField("a", bigDecimalNumber).build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test a=100000000.00000001 1");
+    }
 
-		// Test escaping of equals sign
-		point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar=baz").addField( "a", 1.0 ).build();
-		assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\=baz a=1.0 1");
-	}
+    @Test
+    public void testEscapingOfKeysAndValues() {
+        // Test escaping of spaces
+        Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar baz").addField("a", 1.0)
+                .build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\ baz a=1.0 1");
 
-	@Test
-	public void testDeprecatedFieldMethodOnlyProducesFloatingPointValues() {
-		
-		Object[] ints = {(byte) 1, (short) 1, (int) 1, (long) 1, BigInteger.ONE};
-		
-		for (Object intExample : ints) {
-			Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).field("a", intExample ).build();
-			assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1");
-		}
+        // Test escaping of commas
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar,baz").addField("a", 1.0)
+                .build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\,baz a=1.0 1");
 
-	}
-	/**
-	 * Test for issue #117.
-	 */
-	@Test
-	public void testIgnoreNullPointerValue() {
-		// Test omission of null values
-		Point.Builder pointBuilder = Point.measurement("nulltest").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar");
+        // Test escaping of equals sign
+        point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar=baz").addField("a", 1.0)
+                .build();
+        assertThat(point.lineProtocol()).asString().isEqualTo("test,foo=bar\\=baz a=1.0 1");
+    }
 
-		pointBuilder.field("field1", "value1");
-		pointBuilder.field("field2", (Number) null);
-		pointBuilder.field("field3", (Integer) 1);
+    @Test
+    public void testDeprecatedFieldMethodOnlyProducesFloatingPointValues() {
 
-		Point point = pointBuilder.build();
+        Object[] ints = { (byte) 1, (short) 1, (int) 1, (long) 1, BigInteger.ONE };
 
-		assertThat(point.lineProtocol()).asString().isEqualTo("nulltest,foo=bar field1=\"value1\",field3=1.0 1");
-	}
+        for (Object intExample : ints) {
+            Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).field("a", intExample).build();
+            assertThat(point.lineProtocol()).asString().isEqualTo("test a=1.0 1");
+        }
 
-	/**
-	 * Tests for issue #110
-	 */
-	@Test(expected = IllegalArgumentException.class)
-	public void testAddingTagsWithNullNameThrowsAnError() {
-		Point.measurement("dontcare").tag(null, "DontCare");
-	}
-	
-	@Test(expected = IllegalArgumentException.class)
-	public void testAddingTagsWithNullValueThrowsAnError() {
-		Point.measurement("dontcare").tag("DontCare", null);
-	}
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testAddingMapOfTagsWithNullNameThrowsAnError() {
-		Map<String, String> map = Maps.newHashMap();
-		map.put(null, "DontCare");
-		Point.measurement("dontcare").tag(map);
-	}
+    /**
+     * Test for issue #117.
+     */
+    @Test
+    public void testIgnoreNullPointerValue() {
+        // Test omission of null values
+        Point.Builder pointBuilder = Point.measurement("nulltest").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar");
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testAddingMapOfTagsWithNullValueThrowsAnError() {
-		Map<String, String> map = Maps.newHashMap();
-		map.put("DontCare", null);
-		Point.measurement("dontcare").tag(map);
-	}
-	
-	@Test(expected = IllegalArgumentException.class)
-	public void testNullValueThrowsExceptionViaAddField() {
-		Point.measurement("dontcare").addField("field", (String) null);
-	}
+        pointBuilder.field("field1", "value1");
+        pointBuilder.field("field2", (Number) null);
+        pointBuilder.field("field3", (Integer) 1);
 
-	/**
-	 * Tests for issue #266
-	 */
-	@Test
-	public void testEquals() throws Exception {
-		// GIVEN two point objects with identical data
-		Map<String, Object> fields = Maps.newHashMap();
-		fields.put("foo", "bar");
+        Point point = pointBuilder.build();
 
-		String measurement = "measurement";
+        assertThat(point.lineProtocol()).asString().isEqualTo("nulltest,foo=bar field1=\"value1\",field3=1.0 1");
+    }
 
-		TimeUnit precision = TimeUnit.NANOSECONDS;
+    /**
+     * Tests for issue #110
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddingTagsWithNullNameThrowsAnError() {
+        Point.measurement("dontcare").tag(null, "DontCare");
+    }
 
-		Map<String, String> tags = Maps.newHashMap();
-		tags.put("bar", "baz");
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddingTagsWithNullValueThrowsAnError() {
+        Point.measurement("dontcare").tag("DontCare", null);
+    }
 
-		Long time = System.currentTimeMillis();
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddingMapOfTagsWithNullNameThrowsAnError() {
+        Map<String, String> map = Maps.newHashMap();
+        map.put(null, "DontCare");
+        Point.measurement("dontcare").tag(map);
+    }
 
-		Point p1 = new Point();
-		p1.setFields(fields);
-		p1.setMeasurement(measurement);
-		p1.setPrecision(precision);
-		p1.setTags(tags);
-		p1.setTime(time);
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddingMapOfTagsWithNullValueThrowsAnError() {
+        Map<String, String> map = Maps.newHashMap();
+        map.put("DontCare", null);
+        Point.measurement("dontcare").tag(map);
+    }
 
-		Point p2 = new Point();
-		p2.setFields(fields);
-		p2.setMeasurement(measurement);
-		p2.setPrecision(precision);
-		p2.setTags(tags);
-		p2.setTime(time);
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullValueThrowsExceptionViaAddField() {
+        Point.measurement("dontcare").addField("field", (String) null);
+    }
 
-		// WHEN I call equals on one with the other as arg
-		boolean equals = p1.equals(p2);
+    /**
+     * Tests for issue #266
+     */
+    @Test
+    public void testEquals() throws Exception {
+        // GIVEN two point objects with identical data
+        Map<String, Object> fields = Maps.newHashMap();
+        fields.put("foo", "bar");
 
-		// THEN equals returns true
-		assertThat(equals).isEqualTo(true);
-	}
+        String measurement = "measurement";
 
-	@Test
-	public void testUnEquals() throws Exception {
-		// GIVEN two point objects with different data
-		Map<String, Object> fields1 = Maps.newHashMap();
-		fields1.put("foo", "bar");
+        TimeUnit precision = TimeUnit.NANOSECONDS;
 
-		Map<String, Object> fields2 = Maps.newHashMap();
-		fields2.put("foo", "baz");
+        Map<String, String> tags = Maps.newHashMap();
+        tags.put("bar", "baz");
 
-		String measurement = "measurement";
+        Long time = System.currentTimeMillis();
 
-		TimeUnit precision = TimeUnit.NANOSECONDS;
+        Point p1 = new Point();
+        p1.setFields(fields);
+        p1.setMeasurement(measurement);
+        p1.setPrecision(precision);
+        p1.setTags(tags);
+        p1.setTime(time);
 
-		Map<String, String> tags = Maps.newHashMap();
-		tags.put("bar", "baz");
+        Point p2 = new Point();
+        p2.setFields(fields);
+        p2.setMeasurement(measurement);
+        p2.setPrecision(precision);
+        p2.setTags(tags);
+        p2.setTime(time);
 
-		Long time = System.currentTimeMillis();
+        // WHEN I call equals on one with the other as arg
+        boolean equals = p1.equals(p2);
 
-		Point p1 = new Point();
-		p1.setFields(fields1);
-		p1.setMeasurement(measurement);
-		p1.setPrecision(precision);
-		p1.setTags(tags);
-		p1.setTime(time);
+        // THEN equals returns true
+        assertThat(equals).isEqualTo(true);
+    }
 
-		Point p2 = new Point();
-		p2.setFields(fields2);
-		p2.setMeasurement(measurement);
-		p2.setPrecision(precision);
-		p2.setTags(tags);
-		p2.setTime(time);
+    @Test
+    public void testUnEquals() throws Exception {
+        // GIVEN two point objects with different data
+        Map<String, Object> fields1 = Maps.newHashMap();
+        fields1.put("foo", "bar");
 
-		// WHEN I call equals on one with the other as arg
-		boolean equals = p1.equals(p2);
+        Map<String, Object> fields2 = Maps.newHashMap();
+        fields2.put("foo", "baz");
 
-		// THEN equals returns true
-		assertThat(equals).isEqualTo(false);
-	}
+        String measurement = "measurement";
+
+        TimeUnit precision = TimeUnit.NANOSECONDS;
+
+        Map<String, String> tags = Maps.newHashMap();
+        tags.put("bar", "baz");
+
+        Long time = System.currentTimeMillis();
+
+        Point p1 = new Point();
+        p1.setFields(fields1);
+        p1.setMeasurement(measurement);
+        p1.setPrecision(precision);
+        p1.setTags(tags);
+        p1.setTime(time);
+
+        Point p2 = new Point();
+        p2.setFields(fields2);
+        p2.setMeasurement(measurement);
+        p2.setPrecision(precision);
+        p2.setTags(tags);
+        p2.setTime(time);
+
+        // WHEN I call equals on one with the other as arg
+        boolean equals = p1.equals(p2);
+
+        // THEN equals returns true
+        assertThat(equals).isEqualTo(false);
+    }
+
+    /**
+     * Tests for #182
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLineProtocolNanosecondPrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.NANOSECONDS)
+        String nanosTime = p.lineProtocol(TimeUnit.NANOSECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in nanoseconds
+        assertThat(nanosTime).isEqualTo(String.valueOf(pDate.getTime() * 1000000));
+    }
+
+    @Test
+    public void testLineProtocolMicrosecondPrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.MICROSECONDS)
+        String microsTime = p.lineProtocol(TimeUnit.MICROSECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in microseconds
+        assertThat(microsTime).isEqualTo(String.valueOf(pDate.getTime() * 1000));
+    }
+
+    @Test
+    public void testLineProtocolMillisecondPrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.MILLISECONDS)
+        String millisTime = p.lineProtocol(TimeUnit.MILLISECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in microseconds
+        assertThat(millisTime).isEqualTo(String.valueOf(pDate.getTime()));
+    }
+
+    @Test
+    public void testLineProtocolSecondPrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.SECONDS)
+        String secondTime = p.lineProtocol(TimeUnit.SECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in seconds
+        String expectedSecondTimeStamp = String.valueOf(pDate.getTime() / 1000);
+        assertThat(secondTime).isEqualTo(expectedSecondTimeStamp);
+    }
+
+    @Test
+    public void testLineProtocolMinutePrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.MINUTE)
+        String secondTime = p.lineProtocol(TimeUnit.MINUTES).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in seconds
+        String expectedSecondTimeStamp = String.valueOf(pDate.getTime() / 60000);
+        assertThat(secondTime).isEqualTo(expectedSecondTimeStamp);
+    }
+
+    @Test
+    public void testLineProtocolHourPrecision() throws Exception {
+        // GIVEN a point with millisecond precision
+        Date pDate = new Date();
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(pDate.getTime(), TimeUnit.MILLISECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.NANOSECONDS)
+        String hourTime = p.lineProtocol(TimeUnit.HOURS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in hours
+        String expectedHourTimeStamp = String.valueOf(Math.round(pDate.getTime() / 3600000)); // 1000ms * 60s * 60m
+        assertThat(hourTime).isEqualTo(expectedHourTimeStamp);
+    }
 }


### PR DESCRIPTION
I worked on this a while ago, I was waiting for an answer before commiting so it can't be merged automatically, sorry about that!

Also I wrote some tests but since there's no public test environment I couldn't make them run.