### PR TITLE
Fix NPE when failing to parse an invalid URL

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -96,8 +96,14 @@ public class InfluxDBImpl implements InfluxDB {
   }
 
   private InetAddress parseHostAddress(final String url) {
+      HttpUrl httpUrl = HttpUrl.parse(url);
+
+      if (httpUrl == null) {
+          throw new IllegalArgumentException("Unable to parse url: " + url);
+      }
+
       try {
-          return InetAddress.getByName(HttpUrl.parse(url).host());
+          return InetAddress.getByName(httpUrl.host());
       } catch (UnknownHostException e) {
           throw new RuntimeException(e);
       }

--- a/src/test/java/org/influxdb/InfluxDBFactoryTest.java
+++ b/src/test/java/org/influxdb/InfluxDBFactoryTest.java
@@ -38,4 +38,9 @@ public class InfluxDBFactoryTest {
 		InfluxDB influxDB = InfluxDBFactory.connect("http://" + TestUtils.getInfluxIP() + ":" + TestUtils.getInfluxPORT(true), new OkHttpClient.Builder());
 		verifyInfluxDBInstance(influxDB);
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowIllegalArgumentWithInvalidUrl() {
+		InfluxDBFactory.connect("invalidUrl");
+	}
 }


### PR DESCRIPTION
This is required since HttpUrl.parse() returns null on parse failure.
With this change the Factory now throws an IllegalArgumentException with proper description.

Should fix #331 