### PR TITLE
propagate IOExceptions to consumer

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -97,6 +97,24 @@ public class InfluxDBImpl implements InfluxDB {
     this.adapter = moshi.adapter(QueryResult.class);
   }
 
+    InfluxDBImpl(final String url, final String username, final String password, final OkHttpClient.Builder client,
+            final InfluxDBService influxDBService, final JsonAdapter<QueryResult> adapter) {
+        super();
+        this.hostAddress = parseHostAddress(url);
+        this.username = username;
+        this.password = password;
+        this.loggingInterceptor = new HttpLoggingInterceptor();
+        this.loggingInterceptor.setLevel(Level.NONE);
+        this.gzipRequestInterceptor = new GzipRequestInterceptor();
+        this.retrofit = new Retrofit.Builder()
+                .baseUrl(url)
+                .client(client.addInterceptor(loggingInterceptor).addInterceptor(gzipRequestInterceptor).build())
+                .addConverterFactory(MoshiConverterFactory.create())
+                .build();
+        this.influxDBService = influxDBService;
+        this.adapter = adapter;
+    }
+
   public InfluxDBImpl(final String url, final String username, final String password,
                       final OkHttpClient.Builder client, final String database,
                       final String retentionPolicy, final ConsistencyLevel consistency) {

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -412,7 +412,9 @@ public class InfluxDBImpl implements InfluxDB {
                     queryResult.setError("DONE");
                     consumer.accept(queryResult);
                 } catch (IOException e) {
-                    throw new InfluxDBIOException(e);
+                    QueryResult queryResult = new QueryResult();
+                    queryResult.setError(e.toString());
+                    consumer.accept(queryResult);
                 }
             }
 

--- a/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
+++ b/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
@@ -84,8 +84,6 @@ public class ChunkingExceptionTest {
         QueryResult result = queue.poll(20, TimeUnit.SECONDS);
         Assert.assertNotNull(result);
         Assert.assertEquals(message, result.getError());
-
-        influxDB.deleteDatabase(dbName);
     }
 
 }

--- a/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
+++ b/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
@@ -1,0 +1,89 @@
+package org.influxdb.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.TestUtils;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class ChunkingExceptionTest {
+
+    @Test
+    public void testChunkingIOException() throws IOException, InterruptedException {
+        
+        testChunkingException(new IOException(), "java.io.IOException");
+    }
+
+    @Test
+    public void testChunkingEOFException() throws IOException, InterruptedException {
+
+        testChunkingException(new EOFException(), "DONE");
+    }
+
+    public void testChunkingException(Exception ex, String message) throws IOException, InterruptedException {
+
+        InfluxDBService influxDBService = mock(InfluxDBService.class);
+        JsonAdapter<QueryResult> adapter = mock(JsonAdapter.class);
+        Call<ResponseBody> call = mock(Call.class);
+        ResponseBody responseBody = mock(ResponseBody.class);
+
+        when(influxDBService.query(any(String.class), any(String.class), any(String.class), any(String.class), anyInt())).thenReturn(call);
+        when(responseBody.source()).thenReturn(new Buffer());
+        doThrow(ex).when(adapter).fromJson(any(JsonReader.class));
+
+        String url = "http://" + TestUtils.getInfluxIP() + ":" + TestUtils.getInfluxPORT(true);
+        InfluxDB influxDB = new InfluxDBImpl(url, "admin", "admin", new OkHttpClient.Builder(), influxDBService, adapter) {
+            @Override
+            public String version() {
+                return "9.99";
+            }
+        };
+
+        final BlockingQueue<QueryResult> queue = new LinkedBlockingQueue<>();
+        Query query = new Query("SELECT * FROM disk", "xxx");
+        influxDB.query(query, 2, new Consumer<QueryResult>() {
+            @Override
+            public void accept(QueryResult result) {
+                queue.add(result);
+            }
+        });
+
+        ArgumentCaptor<Callback<ResponseBody>> argumentCaptor = ArgumentCaptor.forClass(Callback.class);
+        verify(call).enqueue(argumentCaptor.capture());
+        Callback<ResponseBody> callback = argumentCaptor.getValue();
+
+        callback.onResponse(call, Response.success(responseBody));
+
+        QueryResult result = queue.poll(20, TimeUnit.SECONDS);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(message, result.getError());
+
+    }
+
+}

--- a/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
+++ b/src/test/java/org/influxdb/impl/ChunkingExceptionTest.java
@@ -65,8 +65,9 @@ public class ChunkingExceptionTest {
             }
         };
 
+        String dbName = "write_unittest_" + System.currentTimeMillis();
         final BlockingQueue<QueryResult> queue = new LinkedBlockingQueue<>();
-        Query query = new Query("SELECT * FROM disk", "xxx");
+        Query query = new Query("SELECT * FROM disk", dbName);
         influxDB.query(query, 2, new Consumer<QueryResult>() {
             @Override
             public void accept(QueryResult result) {
@@ -84,6 +85,7 @@ public class ChunkingExceptionTest {
         Assert.assertNotNull(result);
         Assert.assertEquals(message, result.getError());
 
+        influxDB.deleteDatabase(dbName);
     }
 
 }


### PR DESCRIPTION
We should let the consumer know if there is a IOException and then he can decide what he wants to do. At the moment we simply throw the exception and since this happens in a separate thread the consumer will not be notified. 