### PR TITLE
Fixed DateTimeFormatterBuilder to properly parse nanoseconds

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -52,7 +52,7 @@ public class InfluxDBResultMapper {
     ConcurrentMap<String, ConcurrentMap<String, Field>> CLASS_FIELD_CACHE = new ConcurrentHashMap<>();
 
   private static final int FRACTION_MIN_WIDTH = 0;
-  private static final int FRACTION_MAX_WIDTH = 6;
+  private static final int FRACTION_MAX_WIDTH = 9;
   private static final boolean ADD_DECIMAL_POINT = true;
 
   /**
@@ -61,7 +61,7 @@ public class InfluxDBResultMapper {
    */
   private static final DateTimeFormatter ISO8601_FORMATTER = new DateTimeFormatterBuilder()
     .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-    .appendFraction(ChronoField.MICRO_OF_SECOND, FRACTION_MIN_WIDTH, FRACTION_MAX_WIDTH, ADD_DECIMAL_POINT)
+    .appendFraction(ChronoField.NANO_OF_SECOND, FRACTION_MIN_WIDTH, FRACTION_MAX_WIDTH, ADD_DECIMAL_POINT)
     .appendPattern("X")
     .toFormatter();
 

--- a/src/test/java/org/influxdb/impl/InfluxDBResultMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBResultMapperTest.java
@@ -300,6 +300,27 @@ public class InfluxDBResultMapperTest {
     assertEquals("field 'deviceOsVersion' does not match", "9.3.5", secondGroupByEntry.deviceOsVersion);
   }
 
+  @Test
+  public void testToPOJO_ticket363() {
+    // Given...
+    mapper.cacheMeasurementClass(MyCustomMeasurement.class);
+
+    List<String> columnList = Arrays.asList("time");
+    List<Object> firstSeriesResult = Arrays.asList("2000-01-01T00:00:00.000000001Z");
+
+    QueryResult.Series series = new QueryResult.Series();
+    series.setColumns(columnList);
+    series.setValues(Arrays.asList(firstSeriesResult));
+
+    // When...
+    List<MyCustomMeasurement> result = new LinkedList<>();
+    mapper.parseSeriesAs(series, MyCustomMeasurement.class, result);
+
+    // Then...
+    assertEquals("incorrect number of elemets", 1, result.size());
+    assertEquals("incorrect value for the nanoseconds field", 1, result.get(0).time.getNano());
+  }
+
 	@Measurement(name = "CustomMeasurement")
 	static class MyCustomMeasurement {
 


### PR DESCRIPTION
DateTimeFormatterBuilder was using a wrong value for the max width of a fraction and an incorrect ChronoField. Now it is expected to have up to 9 digits of ns correctly parsed.

This fixes #363.