### PR TITLE
Added 'deprecated' annotations to javadoc and methods

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -342,7 +342,10 @@ public interface InfluxDB {
    *
    * @param name
    *            the name of the new database.
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
+   *             <strong>CREATE DATABASE</strong> query.
    */
+  @Deprecated
   public void createDatabase(final String name);
 
   /**
@@ -350,14 +353,20 @@ public interface InfluxDB {
    *
    * @param name
    *            the name of the database to delete.
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a
+   *             <strong>DROP DATABASE</strong> query.
    */
+  @Deprecated
   public void deleteDatabase(final String name);
 
   /**
    * Describe all available databases.
    *
    * @return a List of all Database names.
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a
+   *             <strong>SHOW DATABASES</strong> query.
    */
+  @Deprecated
   public List<String> describeDatabases();
 
   /**
@@ -367,6 +376,8 @@ public interface InfluxDB {
    *            the name of the database to search.
    *
    * @return true if the database exists or false if it doesn't exist
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a
+   *             <strong>SHOW DATABASES</strong> query and inspect the result.
    */
   public boolean databaseExists(final String name);
 
@@ -418,7 +429,10 @@ public interface InfluxDB {
    * @param shardDuration the shardDuration
    * @param replicationFactor the replicationFactor of the rp
    * @param isDefault if the rp is the default rp for the database or not
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
+   *             <strong>CREATE RETENTION POLICY</strong> query.
    */
+  @Deprecated
   public void createRetentionPolicy(final String rpName, final String database, final String duration,
                                     final String shardDuration, final int replicationFactor, final boolean isDefault);
 
@@ -429,7 +443,10 @@ public interface InfluxDB {
    * @param duration the duration of the rp
    * @param replicationFactor the replicationFactor of the rp
    * @param isDefault if the rp is the default rp for the database or not
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
+   *             <strong>CREATE RETENTION POLICY</strong> query.
    */
+  @Deprecated
   public void createRetentionPolicy(final String rpName, final String database, final String duration,
                                     final int replicationFactor, final boolean isDefault);
 
@@ -440,7 +457,10 @@ public interface InfluxDB {
    * @param duration the duration of the rp
    * @param shardDuration the shardDuration
    * @param replicationFactor the replicationFactor of the rp
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
+   *             <strong>CREATE RETENTION POLICY</strong> query.
    */
+  @Deprecated
   public void createRetentionPolicy(final String rpName, final String database, final String duration,
                                     final String shardDuration, final int replicationFactor);
 
@@ -448,6 +468,9 @@ public interface InfluxDB {
    * Drops a retentionPolicy in a database.
    * @param rpName the name of the retentionPolicy
    * @param database the name of the database
+   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a
+   *             <strong>DROP RETENTION POLICY</strong> query.
    */
+  @Deprecated
   public void dropRetentionPolicy(final String rpName, final String database);
 }


### PR DESCRIPTION
Implements #399 .
@majst01 In addition to
```Java
   /*
   * ... 
   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
   *             <strong>CREATE DATABASE</strong> query.
   */
```
should I make a note like
```Java
   /*
   * ... 
   * @deprecated (since 2.9) Use <tt>org.influxdb.InfluxDB.query(Query)</tt> to execute a parameterized
   *             <strong>CREATE DATABASE</strong> query. Note: this method will be removed on the next major version.
   */
```