### PR TITLE
implement query() call to make asynchronous InfluxDb query with TimeUnit

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -357,6 +357,22 @@ public interface InfluxDB {
   public void query(final Query query, final Consumer<QueryResult> onSuccess, final Consumer<Throwable> onFailure);
 
   /**
+   * Execute a query against a database with ability to specify the time unit.
+   *
+   * One of the consumers will be executed.
+   *
+   * @param query
+   *            the query to execute.
+   * @param timeUnit the time unit of the results.
+   * @param onSuccess
+   *            the consumer to invoke when result is received
+   * @param onFailure
+   *            the consumer to invoke when error is thrown
+   */
+  public void query(final Query query, TimeUnit timeUnit,
+                    final Consumer<QueryResult> onSuccess, final Consumer<Throwable> onFailure);
+
+  /**
    * Execute a streaming query against a database.
    *
    * @param query


### PR DESCRIPTION
Hi

This change introduces a non-blocking query() call that also allows for the TimeUnit parameter to get timestamps in microseconds or nanoseconds rather than in RFC3339. Currently (in the upstream master) we either can do a non-blocking call (with onSuccess and onFailure callbacks) but get timestamps in RFC3339, or specify timestamp unit but then the call is blocking. This change provides a way to have both.

thank you
Vadim Kurland
