### PR TITLE
Parameter binding in InfluxQL (influxdata/influxdb-java#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.10 [unreleased]
+
+### Features
+
+- Support for parameter binding in queries ("prepared statements") [PR #429](https://github.com/influxdata/influxdb-java/pull/429)
+
 ## 2.9 [2018-02-27]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -263,6 +263,22 @@ this.influxDB.query(new Query("SELECT idle FROM cpu", dbName), queryResult -> {
 });
 ```
 
+#### Query using parameter binding ("prepared statements", version 2.10+ required)
+
+If your Query is based on user input, it is good practice to use parameter binding to avoid [injection attacks](https://en.wikipedia.org/wiki/SQL_injection).
+You can create queries with parameter binding with the help of the QueryBuilder:
+
+```java
+Query query = QueryBuilder.newQuery("SELECT * FROM cpu WHERE idle > $idle AND system > $system") 
+        .forDatabase(dbName)
+        .bind("idle", 90)
+        .bind("system", 5)
+        .create();
+QueryResult results = influxDB.query(query);
+```
+
+The values of the bind() calls are bound to the placeholders in the query ($idle, $system). 
+
 #### Batch flush interval jittering (version 2.9+ required)
 
 When using large number of influxdb-java clients against a single server it may happen that all the clients 

--- a/src/main/java/org/influxdb/dto/BoundParameterQuery.java
+++ b/src/main/java/org/influxdb/dto/BoundParameterQuery.java
@@ -1,0 +1,81 @@
+package org.influxdb.dto;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.squareup.moshi.JsonWriter;
+
+import okio.Buffer;
+
+public class BoundParameterQuery extends Query {
+
+    private final Object[] params;
+
+    public BoundParameterQuery(final String command, final String database, final Object...params) {
+        super(command, database, true);
+        this.params = params;
+    }
+
+    public String getParameterJsonWithUrlEncoded() {
+        try {
+            List<String> placeholders = parsePlaceHolders(getCommand());
+            Map<String, Object> parameterMap = createParameterMap(placeholders, params);
+            String jsonParameterObject = createJsonObject(parameterMap);
+            String urlEncodedJsonParameterObject = encode(jsonParameterObject);
+            return urlEncodedJsonParameterObject;
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't create parameter JSON object", e);
+        }
+    }
+
+    private String createJsonObject(final Map<String, Object> parameterMap) throws IOException {
+        Buffer b = new Buffer();
+        JsonWriter writer = JsonWriter.of(b);
+        writer.beginObject();
+        for (Entry<String, Object> pair : parameterMap.entrySet()) {
+            String name = pair.getKey();
+            Object value = pair.getValue();
+            if (value instanceof Number) {
+                writer.name(name).value((Number) value);
+            } else if (value instanceof String) {
+                writer.name(name).value((String) value);
+            } else if (value instanceof Boolean) {
+                writer.name(name).value((Boolean) value);
+            } else {
+                writer.name(name).value(value.toString());
+            }
+        }
+        writer.endObject();
+        return b.readString(Charset.forName("utf-8"));
+    }
+
+    private Map<String, Object> createParameterMap(final List<String> placeholders, final Object[] params) {
+        if (placeholders.size() != params.length) {
+            throw new RuntimeException("Unbalanced amount of placeholders and parameters");
+        }
+
+        Map<String, Object> parameterMap = new HashMap<>();
+        int index = 0;
+        for (String placeholder : placeholders) {
+            parameterMap.put(placeholder, params[index++]);
+        }
+        return parameterMap;
+    }
+
+    private List<String> parsePlaceHolders(final String command) {
+        List<String> placeHolders = new ArrayList<>();
+        Pattern p = Pattern.compile("\\s+\\$(\\w+?)(?:\\s|$)");
+        Matcher m = p.matcher(getCommand());
+        while (m.find()) {
+            placeHolders.add(m.group(1));
+        }
+        return placeHolders;
+    }
+}

--- a/src/main/java/org/influxdb/dto/BoundParameterQuery.java
+++ b/src/main/java/org/influxdb/dto/BoundParameterQuery.java
@@ -75,6 +75,26 @@ public class BoundParameterQuery extends Query {
         return placeHolders;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + params.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        BoundParameterQuery other = (BoundParameterQuery) obj;
+        if (!params.equals(other.params))
+            return false;
+        return true;
+    }
+
     public static class QueryBuilder {
         private BoundParameterQuery query;
         private String influxQL;

--- a/src/main/java/org/influxdb/dto/BoundParameterQuery.java
+++ b/src/main/java/org/influxdb/dto/BoundParameterQuery.java
@@ -20,11 +20,6 @@ public class BoundParameterQuery extends Query {
         super(command, database, true);
     }
 
-    public BoundParameterQuery bind(String placeholder, Object value) {
-        params.put(placeholder, value);
-        return this;
-    }
-
     public String getParameterJsonWithUrlEncoded() {
         try {
             List<String> placeholders = parsePlaceHolders(getCommand());

--- a/src/main/java/org/influxdb/dto/BoundParameterQuery.java
+++ b/src/main/java/org/influxdb/dto/BoundParameterQuery.java
@@ -3,13 +3,12 @@ package org.influxdb.dto;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import org.influxdb.InfluxDBIOException;
+
 import okio.Buffer;
 
 public final class BoundParameterQuery extends Query {
@@ -22,25 +21,11 @@ public final class BoundParameterQuery extends Query {
 
   public String getParameterJsonWithUrlEncoded() {
     try {
-      List<String> placeholders = parsePlaceHolders(getCommand());
-      assurePlaceholdersAreBound(placeholders, params);
       String jsonParameterObject = createJsonObject(params);
       String urlEncodedJsonParameterObject = encode(jsonParameterObject);
       return urlEncodedJsonParameterObject;
     } catch (IOException e) {
-      throw new RuntimeException("Couldn't create parameter JSON object", e);
-    }
-  }
-
-  private void assurePlaceholdersAreBound(final List<String> placeholders, final Map<String, Object> params) {
-    if (placeholders.size() != params.size()) {
-      throw new RuntimeException("Unbalanced amount of placeholders and parameters");
-    }
-
-    for (String placeholder : placeholders) {
-      if (params.get(placeholder) == null) {
-        throw new RuntimeException("Placeholder $" + placeholder + " is not bound");
-      }
+      throw new InfluxDBIOException(e);
     }
   }
 
@@ -52,27 +37,18 @@ public final class BoundParameterQuery extends Query {
       String name = pair.getKey();
       Object value = pair.getValue();
       if (value instanceof Number) {
-        writer.name(name).value((Number) value);
+        Number number = (Number) value;
+        writer.name(name).value(number);
       } else if (value instanceof String) {
         writer.name(name).value((String) value);
       } else if (value instanceof Boolean) {
         writer.name(name).value((Boolean) value);
       } else {
-        writer.name(name).value(value.toString());
+        writer.name(name).value(String.valueOf(value));
       }
     }
     writer.endObject();
     return b.readString(Charset.forName("utf-8"));
-  }
-
-  private List<String> parsePlaceHolders(final String command) {
-    List<String> placeHolders = new ArrayList<>();
-    Pattern p = Pattern.compile("\\s+\\$(\\w+?)(?:\\s|$)");
-    Matcher m = p.matcher(getCommand());
-    while (m.find()) {
-      placeHolders.add(m.group(1));
-    }
-    return placeHolders;
   }
 
   @Override

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -18,6 +18,7 @@ interface InfluxDBService {
   public static final String Q = "q";
   public static final String DB = "db";
   public static final String RP = "rp";
+  public static final String PARAMS = "params";
   public static final String PRECISION = "precision";
   public static final String CONSISTENCY = "consistency";
   public static final String EPOCH = "epoch";
@@ -47,6 +48,11 @@ interface InfluxDBService {
   public Call<QueryResult> query(@Query(U) String username, @Query(P) String password, @Query(DB) String db,
       @Query(EPOCH) String epoch, @Query(value = Q, encoded = true) String query);
 
+  @POST("/query")
+  public Call<QueryResult> query(@Query(U) String username, @Query(P) String password, @Query(DB) String db,
+          @Query(EPOCH) String epoch, @Query(value = Q, encoded = true) String query,
+          @Query(value = PARAMS, encoded = true) String params);
+
   @GET("/query")
   public Call<QueryResult> query(@Query(U) String username, @Query(P) String password, @Query(DB) String db,
       @Query(value = Q, encoded = true) String query);
@@ -54,6 +60,10 @@ interface InfluxDBService {
   @POST("/query")
   public Call<QueryResult> postQuery(@Query(U) String username, @Query(P) String password, @Query(DB) String db,
       @Query(value = Q, encoded = true) String query);
+
+  @POST("/query")
+  public Call<QueryResult> postQuery(@Query(U) String username, @Query(P) String password, @Query(DB) String db,
+          @Query(value = Q, encoded = true) String query, @Query(value = PARAMS, encoded = true) String params);
 
   @GET("/query")
   public Call<QueryResult> query(@Query(U) String username, @Query(P) String password,
@@ -68,4 +78,10 @@ interface InfluxDBService {
   public Call<ResponseBody> query(@Query(U) String username,
       @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query,
       @Query(CHUNK_SIZE) int chunkSize);
+
+  @Streaming
+  @POST("/query?chunked=true")
+  public Call<ResponseBody> query(@Query(U) String username,
+          @Query(P) String password, @Query(DB) String db, @Query(value = Q, encoded = true) String query,
+          @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
 }

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -1,0 +1,93 @@
+package org.influxdb.dto;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import com.squareup.moshi.JsonReader;
+
+import okio.Buffer;
+
+
+/**
+ * Test for the BoundParameterQuery DTO.
+ */
+@RunWith(JUnitPlatform.class)
+public class BoundParameterQueryTest {
+
+	@Test
+	public void testSingleCharacterPlaceHolderParsing() throws IOException {
+	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $a AND b < $b", "foobar", 0, 10);
+	    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+	    Assert.assertEquals(2, params.size());
+	    Assert.assertEquals(params.get("a"), 0.0);
+	    Assert.assertEquals(params.get("b"), 10.0);
+	}
+
+	@Test
+	public void testPlaceHolderParsing() throws IOException {
+	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd", "foobar", 0, 10);
+	    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+	    Assert.assertEquals(2, params.size());
+        Assert.assertEquals(params.get("abc"), 0.0);
+        Assert.assertEquals(params.get("bcd"), 10.0);
+	}
+
+	@Test
+	public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
+	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $", "foobar");
+	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+	    
+	    query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc$cde", "foobar");
+	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+	}
+
+	@Test
+	public void testUnbalancedQuery() throws UnsupportedEncodingException {
+	    // too many placeholders
+	    try {
+	        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd", "foobar", 0);
+	        query.getParameterJsonWithUrlEncoded();
+	        Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+	    } catch (RuntimeException rte) {
+	        // expected
+	    }
+
+	    // too many parameters
+	    try {
+	        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc", "foobar", 0, 10);
+	        query.getParameterJsonWithUrlEncoded();
+	        Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+	    } catch (RuntimeException rte) {
+	        // expected
+	    }
+	}
+	
+	private Map<String, Object> readObject(String json) throws IOException {
+	    Buffer source = new Buffer();
+	    source.writeString(json, Charset.forName("utf-8"));
+	    Map<String, Object> params = new HashMap<>();
+	    JsonReader reader = JsonReader.of(source);
+	    reader.beginObject();
+        while(reader.hasNext()) {
+            String name = reader.nextName();
+            Object value = reader.readJsonValue();
+            params.put(name, value);
+        }
+	    reader.endObject();
+	    return params;
+	}
+	
+	private static String decode(String str) throws UnsupportedEncodingException {
+        return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
+    }
+}

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -26,148 +26,146 @@ import okio.Buffer;
 @RunWith(JUnitPlatform.class)
 public class BoundParameterQueryTest {
 
-    @Test
-    public void testSingleCharacterPlaceHolderParsing() throws IOException {
-        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $a AND b < $b")
-                .forDatabase("foobar")
-                .bind("a", 0)
-                .bind("b", 10)
-                .create();
-        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-        Assert.assertEquals(2, params.size());
-        Assert.assertEquals(params.get("a"), 0.0);
-        Assert.assertEquals(params.get("b"), 10.0);
+  @Test
+  public void testSingleCharacterPlaceHolderParsing() throws IOException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $a AND b < $b")
+        .forDatabase("foobar")
+        .bind("a", 0)
+        .bind("b", 10)
+        .create();
+    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+    Assert.assertEquals(2, params.size());
+    Assert.assertEquals(params.get("a"), 0.0);
+    Assert.assertEquals(params.get("b"), 10.0);
+  }
+
+  @Test
+  public void testPlaceHolderParsing() throws IOException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
+        .forDatabase("foobar")
+        .bind("abc", 0)
+        .bind("bcd", 10)
+        .create();
+    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+    Assert.assertEquals(2, params.size());
+    Assert.assertEquals(params.get("abc"), 0.0);
+    Assert.assertEquals(params.get("bcd"), 10.0);
+  }
+
+  @Test
+  public void testPlaceHolderParsingWithLimitClause() throws IOException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10")
+        .forDatabase("foobar")
+        .bind("abc", 0)
+        .bind("bcd", 10)
+        .create();
+    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+    Assert.assertEquals(2, params.size());
+    Assert.assertEquals(params.get("abc"), 0.0);
+    Assert.assertEquals(params.get("bcd"), 10.0);
+  }
+
+  @Test
+  public void testDifferentTypePlaceHolderParsing() throws IOException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE number > $number"
+        + " AND bool = $bool AND string = $string AND other = $object")
+        .forDatabase("foobar")
+        .bind("number", 0)
+        .bind("bool", true)
+        .bind("string", "test")
+        .bind("object", new Object())
+        .create();
+    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+    Assert.assertEquals(4, params.size());
+    Assert.assertEquals(params.get("number"), 0.0);
+    Assert.assertEquals(params.get("bool"), true);
+    Assert.assertEquals(params.get("string"), "test");
+    Assert.assertTrue(((String)params.get("object")).matches("java.lang.Object@[a-z0-9]+"));
+  }
+
+  @Test
+  public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $")
+        .forDatabase("foobar")
+        .create();
+    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+
+    query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc$cde").forDatabase("foobar").create();
+    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+  }
+
+  @Test
+  public void testUnbalancedQuery() throws UnsupportedEncodingException {
+    // too many placeholders
+    try {
+      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
+          .forDatabase("foobar")
+          .bind("abc", 0)
+          .create();
+      query.getParameterJsonWithUrlEncoded();
+      Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+    } catch (RuntimeException rte) {
+      // expected
     }
 
-    @Test
-    public void testPlaceHolderParsing() throws IOException {
-        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
-                .forDatabase("foobar")
-                .bind("abc", 0)
-                .bind("bcd", 10)
-                .create();
-        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-        Assert.assertEquals(2, params.size());
-        Assert.assertEquals(params.get("abc"), 0.0);
-        Assert.assertEquals(params.get("bcd"), 10.0);
+    // too many parameters
+    try {
+      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
+          .forDatabase("foobar")
+          .bind("abc", 0)
+          .bind("bcd", 10)
+          .create();
+      query.getParameterJsonWithUrlEncoded();
+      Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+    } catch (RuntimeException rte) {
+      // expected
     }
+  }
 
-    @Test
-    public void testPlaceHolderParsingWithLimitClause() throws IOException {
-        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10")
-                .forDatabase("foobar")
-                .bind("abc", 0)
-                .bind("bcd", 10)
-                .create();
-        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-        Assert.assertEquals(2, params.size());
-        Assert.assertEquals(params.get("abc"), 0.0);
-        Assert.assertEquals(params.get("bcd"), 10.0);
+  @Test
+  public void testEqualsAndHashCode() {
+    String stringA0 = "SELECT * FROM foobar WHERE a = $a";
+    String stringA1 = "SELECT * FROM foobar WHERE a = $a";
+    String stringB0 = "SELECT * FROM foobar WHERE b = $b";
+
+    Query queryA0 = QueryBuilder.newQuery(stringA0)
+        .forDatabase(stringA0)
+        .bind("a", 0)
+        .create();
+    Query queryA1 = QueryBuilder.newQuery(stringA1)
+        .forDatabase(stringA1)
+        .bind("a", 0)
+        .create();
+    Query queryB0 = QueryBuilder.newQuery(stringB0)
+        .forDatabase(stringB0)
+        .bind("b", 10)
+        .create();
+
+    assertThat(queryA0).isEqualTo(queryA0);
+    assertThat(queryA0).isEqualTo(queryA1);
+    assertThat(queryA0).isNotEqualTo(queryB0);
+    assertThat(queryA0).isNotEqualTo("foobar");
+
+    assertThat(queryA0.hashCode()).isEqualTo(queryA1.hashCode());
+    assertThat(queryA0.hashCode()).isNotEqualTo(queryB0.hashCode());
+  }
+
+  private Map<String, Object> readObject(String json) throws IOException {
+    Buffer source = new Buffer();
+    source.writeString(json, Charset.forName("utf-8"));
+    Map<String, Object> params = new HashMap<>();
+    JsonReader reader = JsonReader.of(source);
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      Object value = reader.readJsonValue();
+      params.put(name, value);
     }
+    reader.endObject();
+    return params;
+  }
 
-    @Test
-    public void testDifferentTypePlaceHolderParsing() throws IOException {
-        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE number > $number"
-                + " AND bool = $bool AND string = $string AND other = $object")
-                .forDatabase("foobar")
-                .bind("number", 0)
-                .bind("bool", true)
-                .bind("string", "test")
-                .bind("object", new Object())
-                .create();
-        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-        Assert.assertEquals(4, params.size());
-        Assert.assertEquals(params.get("number"), 0.0);
-        Assert.assertEquals(params.get("bool"), true);
-        Assert.assertEquals(params.get("string"), "test");
-        Assert.assertTrue(((String)params.get("object")).matches("java.lang.Object@[a-z0-9]+"));
-    }
-
-    @Test
-    public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
-        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $")
-                .forDatabase("foobar")
-                .create();
-        Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-
-        query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc$cde").forDatabase("foobar").create();
-        Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-    }
-
-    @Test
-    public void testUnbalancedQuery() throws UnsupportedEncodingException {
-        // too many placeholders
-        try {
-            BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
-                    .forDatabase("foobar")
-                    .bind("abc", 0)
-                    .create();
-            query.getParameterJsonWithUrlEncoded();
-            Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-        } catch (RuntimeException rte) {
-            // expected
-        }
-
-        // too many parameters
-        try {
-            BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
-                    .forDatabase("foobar")
-                    .bind("abc", 0)
-                    .bind("bcd", 10)
-                    .create();
-            query.getParameterJsonWithUrlEncoded();
-            Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-        } catch (RuntimeException rte) {
-            // expected
-        }
-    }
-    
-    @Test
-    public void testEqualsAndHashCode() {
-        String stringA0 = "SELECT * FROM foobar WHERE a = $a";
-        String stringA1 = "SELECT * FROM foobar WHERE a = $a";
-        String stringB0 = "SELECT * FROM foobar WHERE b = $b";
-
-        Query queryA0 = QueryBuilder.newQuery(stringA0)
-                .forDatabase(stringA0)
-                .bind("a", 0)
-                .create();
-        Query queryA1 = QueryBuilder.newQuery(stringA1)
-                .forDatabase(stringA1)
-                .bind("a", 0)
-                .create();
-        Query queryB0 = QueryBuilder.newQuery(stringB0)
-                .forDatabase(stringB0)
-                .bind("b", 10)
-                .create();
-//        Query queryC0 = new Query(stringB0, stringA0);
-
-        assertThat(queryA0).isEqualTo(queryA0);
-        assertThat(queryA0).isEqualTo(queryA1);
-        assertThat(queryA0).isNotEqualTo(queryB0);
-        assertThat(queryA0).isNotEqualTo("foobar");
-//        assertThat(queryB0).isNotEqualTo(queryC0);
-
-        assertThat(queryA0.hashCode()).isEqualTo(queryA1.hashCode());
-        assertThat(queryA0.hashCode()).isNotEqualTo(queryB0.hashCode());
-    }
-
-    private Map<String, Object> readObject(String json) throws IOException {
-        Buffer source = new Buffer();
-        source.writeString(json, Charset.forName("utf-8"));
-        Map<String, Object> params = new HashMap<>();
-        JsonReader reader = JsonReader.of(source);
-        reader.beginObject();
-        while (reader.hasNext()) {
-            String name = reader.nextName();
-            Object value = reader.readJsonValue();
-            params.put(name, value);
-        }
-        reader.endObject();
-        return params;
-    }
-
-    private static String decode(String str) throws UnsupportedEncodingException {
-        return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
-    }
+  private static String decode(String str) throws UnsupportedEncodingException {
+    return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
+  }
 }

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -5,10 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.influxdb.dto.BoundParameterQuery.QueryBuilder;
 import org.junit.Assert;
@@ -16,9 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
-import com.squareup.moshi.JsonReader;
-
-import okio.Buffer;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
 
 /**
  * Test for the BoundParameterQuery DTO.
@@ -27,111 +23,25 @@ import okio.Buffer;
 public class BoundParameterQueryTest {
 
   @Test
-  public void testSingleCharacterPlaceHolderParsing() throws IOException {
-    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $a AND b < $b")
+  public void testGetParameterJsonWithUrlEncoded() throws IOException {
+    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE integer > $i"
+        + "AND double = $d AND bool = $bool AND string = $string AND other = $object")
         .forDatabase("foobar")
-        .bind("a", 0)
-        .bind("b", 10)
-        .create();
-    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-    Assert.assertEquals(2, params.size());
-    Assert.assertEquals(params.get("a"), 0.0);
-    Assert.assertEquals(params.get("b"), 10.0);
-  }
-
-  @Test
-  public void testPlaceHolderParsing() throws IOException {
-    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
-        .forDatabase("foobar")
-        .bind("abc", 0)
-        .bind("bcd", 10)
-        .create();
-    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-    Assert.assertEquals(2, params.size());
-    Assert.assertEquals(params.get("abc"), 0.0);
-    Assert.assertEquals(params.get("bcd"), 10.0);
-  }
-
-  @Test
-  public void testPlaceHolderParsingWithLimitClause() throws IOException {
-    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10")
-        .forDatabase("foobar")
-        .bind("abc", 0)
-        .bind("bcd", 10)
-        .create();
-    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-    Assert.assertEquals(2, params.size());
-    Assert.assertEquals(params.get("abc"), 0.0);
-    Assert.assertEquals(params.get("bcd"), 10.0);
-  }
-
-  @Test
-  public void testDifferentTypePlaceHolderParsing() throws IOException {
-    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE number > $number"
-        + " AND bool = $bool AND string = $string AND other = $object")
-        .forDatabase("foobar")
-        .bind("number", 0)
+        .bind("i", 0)
+        .bind("d", 1.0)
         .bind("bool", true)
         .bind("string", "test")
         .bind("object", new Object())
         .create();
-    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-    Assert.assertEquals(4, params.size());
-    Assert.assertEquals(params.get("number"), 0.0);
-    Assert.assertEquals(params.get("bool"), true);
-    Assert.assertEquals(params.get("string"), "test");
-    Assert.assertTrue(((String)params.get("object")).matches("java.lang.Object@[a-z0-9]+"));
-  }
-
-  @Test
-  public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
-    BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $")
-        .forDatabase("foobar")
-        .create();
-    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-
-    query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc$cde").forDatabase("foobar").create();
-    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-  }
-
-  @Test
-  public void testUnbalancedQuery() throws UnsupportedEncodingException {
-    // too many placeholders
-    try {
-      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
-          .forDatabase("foobar")
-          .bind("abc", 0)
-          .create();
-      query.getParameterJsonWithUrlEncoded();
-      Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-    } catch (RuntimeException rte) {
-      // expected
-    }
-
-    // too many parameters
-    try {
-      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
-          .forDatabase("foobar")
-          .bind("abc", 0)
-          .bind("bcd", 10)
-          .create();
-      query.getParameterJsonWithUrlEncoded();
-      Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-    } catch (RuntimeException rte) {
-      // expected
-    }
-
-    // unbound placeholder
-    try {
-      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
-          .forDatabase("foobar")
-          .bind("bcd", 10)
-          .create();
-      query.getParameterJsonWithUrlEncoded();
-      Assert.fail("Expected RuntimeException because of unbound placeholder");
-    } catch (RuntimeException rte) {
-      // expected
-    }
+    
+    Moshi moshi = new Moshi.Builder().build();
+    JsonAdapter<Point> adapter = moshi.adapter(Point.class);
+    Point point = adapter.fromJson(decode(query.getParameterJsonWithUrlEncoded()));
+    Assert.assertEquals(0, point.i);
+    Assert.assertEquals(1.0, point.d, 0.0);
+    Assert.assertEquals(true, point.bool);
+    Assert.assertEquals("test", point.string);
+    Assert.assertTrue(point.object.matches("java.lang.Object@[a-z0-9]+"));
   }
 
   @Test
@@ -167,22 +77,15 @@ public class BoundParameterQueryTest {
     assertThat(queryA0.hashCode()).isNotEqualTo(queryB0.hashCode());
   }
 
-  private Map<String, Object> readObject(String json) throws IOException {
-    Buffer source = new Buffer();
-    source.writeString(json, Charset.forName("utf-8"));
-    Map<String, Object> params = new HashMap<>();
-    JsonReader reader = JsonReader.of(source);
-    reader.beginObject();
-    while (reader.hasNext()) {
-      String name = reader.nextName();
-      Object value = reader.readJsonValue();
-      params.put(name, value);
-    }
-    reader.endObject();
-    return params;
-  }
-
   private static String decode(String str) throws UnsupportedEncodingException {
     return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
+  }
+  
+  private static class Point {
+    int i;
+    double d;
+    String string;
+    Boolean bool;
+    String object;
   }
 }

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -120,6 +120,18 @@ public class BoundParameterQueryTest {
     } catch (RuntimeException rte) {
       // expected
     }
+
+    // unbound placeholder
+    try {
+      BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
+          .forDatabase("foobar")
+          .bind("bcd", 10)
+          .create();
+      query.getParameterJsonWithUrlEncoded();
+      Assert.fail("Expected RuntimeException because of unbound placeholder");
+    } catch (RuntimeException rte) {
+      // expected
+    }
   }
 
   @Test
@@ -136,6 +148,10 @@ public class BoundParameterQueryTest {
         .forDatabase(stringA1)
         .bind("a", 0)
         .create();
+    Query queryA2 = QueryBuilder.newQuery(stringA1)
+        .forDatabase(stringA1)
+        .bind("a", 10)
+        .create();
     Query queryB0 = QueryBuilder.newQuery(stringB0)
         .forDatabase(stringB0)
         .bind("b", 10)
@@ -143,6 +159,7 @@ public class BoundParameterQueryTest {
 
     assertThat(queryA0).isEqualTo(queryA0);
     assertThat(queryA0).isEqualTo(queryA1);
+    assertThat(queryA0).isNotEqualTo(queryA2);
     assertThat(queryA0).isNotEqualTo(queryB0);
     assertThat(queryA0).isNotEqualTo("foobar");
 

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -1,5 +1,7 @@
 package org.influxdb.dto;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -118,6 +120,36 @@ public class BoundParameterQueryTest {
         } catch (RuntimeException rte) {
             // expected
         }
+    }
+    
+    @Test
+    public void testEqualsAndHashCode() {
+        String stringA0 = "SELECT * FROM foobar WHERE a = $a";
+        String stringA1 = "SELECT * FROM foobar WHERE a = $a";
+        String stringB0 = "SELECT * FROM foobar WHERE b = $b";
+
+        Query queryA0 = QueryBuilder.newQuery(stringA0)
+                .forDatabase(stringA0)
+                .bind("a", 0)
+                .create();
+        Query queryA1 = QueryBuilder.newQuery(stringA1)
+                .forDatabase(stringA1)
+                .bind("a", 0)
+                .create();
+        Query queryB0 = QueryBuilder.newQuery(stringB0)
+                .forDatabase(stringB0)
+                .bind("b", 10)
+                .create();
+//        Query queryC0 = new Query(stringB0, stringA0);
+
+        assertThat(queryA0).isEqualTo(queryA0);
+        assertThat(queryA0).isEqualTo(queryA1);
+        assertThat(queryA0).isNotEqualTo(queryB0);
+        assertThat(queryA0).isNotEqualTo("foobar");
+//        assertThat(queryB0).isNotEqualTo(queryC0);
+
+        assertThat(queryA0.hashCode()).isEqualTo(queryA1.hashCode());
+        assertThat(queryA0.hashCode()).isNotEqualTo(queryB0.hashCode());
     }
 
     private Map<String, Object> readObject(String json) throws IOException {

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -64,6 +64,24 @@ public class BoundParameterQueryTest {
     }
 
     @Test
+    public void testDifferentTypePlaceHolderParsing() throws IOException {
+        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE number > $number"
+                + " AND bool = $bool AND string = $string AND other = $object")
+                .forDatabase("foobar")
+                .bind("number", 0)
+                .bind("bool", true)
+                .bind("string", "test")
+                .bind("object", new Object())
+                .create();
+        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+        Assert.assertEquals(4, params.size());
+        Assert.assertEquals(params.get("number"), 0.0);
+        Assert.assertEquals(params.get("bool"), true);
+        Assert.assertEquals(params.get("string"), "test");
+        Assert.assertTrue(((String)params.get("object")).matches("java.lang.Object@[a-z0-9]+"));
+    }
+
+    @Test
     public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
         BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $")
                 .forDatabase("foobar")

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -43,10 +43,19 @@ public class BoundParameterQueryTest {
 	}
 
 	@Test
+    public void testPlaceHolderParsingWithLimitClause() throws IOException {
+        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10", "foobar", 0, 10);
+        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+        Assert.assertEquals(2, params.size());
+        Assert.assertEquals(params.get("abc"), 0.0);
+        Assert.assertEquals(params.get("bcd"), 10.0);
+    }
+
+	@Test
 	public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
 	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $", "foobar");
 	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-	    
+
 	    query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc$cde", "foobar");
 	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
 	}
@@ -71,7 +80,7 @@ public class BoundParameterQueryTest {
 	        // expected
 	    }
 	}
-	
+
 	private Map<String, Object> readObject(String json) throws IOException {
 	    Buffer source = new Buffer();
 	    source.writeString(json, Charset.forName("utf-8"));
@@ -86,7 +95,7 @@ public class BoundParameterQueryTest {
 	    reader.endObject();
 	    return params;
 	}
-	
+
 	private static String decode(String str) throws UnsupportedEncodingException {
         return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
     }

--- a/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
+++ b/src/test/java/org/influxdb/dto/BoundParameterQueryTest.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.influxdb.dto.BoundParameterQuery.QueryBuilder;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.runner.JUnitPlatform;
@@ -17,86 +18,106 @@ import com.squareup.moshi.JsonReader;
 
 import okio.Buffer;
 
-
 /**
  * Test for the BoundParameterQuery DTO.
  */
 @RunWith(JUnitPlatform.class)
 public class BoundParameterQueryTest {
 
-	@Test
-	public void testSingleCharacterPlaceHolderParsing() throws IOException {
-	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $a AND b < $b", "foobar", 0, 10);
-	    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-	    Assert.assertEquals(2, params.size());
-	    Assert.assertEquals(params.get("a"), 0.0);
-	    Assert.assertEquals(params.get("b"), 10.0);
-	}
+    @Test
+    public void testSingleCharacterPlaceHolderParsing() throws IOException {
+        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $a AND b < $b")
+                .forDatabase("foobar")
+                .bind("a", 0)
+                .bind("b", 10)
+                .create();
+        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+        Assert.assertEquals(2, params.size());
+        Assert.assertEquals(params.get("a"), 0.0);
+        Assert.assertEquals(params.get("b"), 10.0);
+    }
 
-	@Test
-	public void testPlaceHolderParsing() throws IOException {
-	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd", "foobar", 0, 10);
-	    Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
-	    Assert.assertEquals(2, params.size());
-        Assert.assertEquals(params.get("abc"), 0.0);
-        Assert.assertEquals(params.get("bcd"), 10.0);
-	}
-
-	@Test
-    public void testPlaceHolderParsingWithLimitClause() throws IOException {
-        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10", "foobar", 0, 10);
+    @Test
+    public void testPlaceHolderParsing() throws IOException {
+        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
+                .forDatabase("foobar")
+                .bind("abc", 0)
+                .bind("bcd", 10)
+                .create();
         Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
         Assert.assertEquals(2, params.size());
         Assert.assertEquals(params.get("abc"), 0.0);
         Assert.assertEquals(params.get("bcd"), 10.0);
     }
 
-	@Test
-	public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
-	    BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $", "foobar");
-	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+    @Test
+    public void testPlaceHolderParsingWithLimitClause() throws IOException {
+        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd LIMIT 10")
+                .forDatabase("foobar")
+                .bind("abc", 0)
+                .bind("bcd", 10)
+                .create();
+        Map<String, Object> params = readObject(decode(query.getParameterJsonWithUrlEncoded()));
+        Assert.assertEquals(2, params.size());
+        Assert.assertEquals(params.get("abc"), 0.0);
+        Assert.assertEquals(params.get("bcd"), 10.0);
+    }
 
-	    query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc$cde", "foobar");
-	    Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
-	}
+    @Test
+    public void testIgnoreInvalidPlaceholders() throws UnsupportedEncodingException {
+        BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $")
+                .forDatabase("foobar")
+                .create();
+        Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
 
-	@Test
-	public void testUnbalancedQuery() throws UnsupportedEncodingException {
-	    // too many placeholders
-	    try {
-	        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd", "foobar", 0);
-	        query.getParameterJsonWithUrlEncoded();
-	        Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-	    } catch (RuntimeException rte) {
-	        // expected
-	    }
+        query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc$cde").forDatabase("foobar").create();
+        Assert.assertEquals(decode(query.getParameterJsonWithUrlEncoded()), "{}");
+    }
 
-	    // too many parameters
-	    try {
-	        BoundParameterQuery query = new BoundParameterQuery("SELECT * FROM abc WHERE a > $abc", "foobar", 0, 10);
-	        query.getParameterJsonWithUrlEncoded();
-	        Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
-	    } catch (RuntimeException rte) {
-	        // expected
-	    }
-	}
+    @Test
+    public void testUnbalancedQuery() throws UnsupportedEncodingException {
+        // too many placeholders
+        try {
+            BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc AND b < $bcd")
+                    .forDatabase("foobar")
+                    .bind("abc", 0)
+                    .create();
+            query.getParameterJsonWithUrlEncoded();
+            Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+        } catch (RuntimeException rte) {
+            // expected
+        }
 
-	private Map<String, Object> readObject(String json) throws IOException {
-	    Buffer source = new Buffer();
-	    source.writeString(json, Charset.forName("utf-8"));
-	    Map<String, Object> params = new HashMap<>();
-	    JsonReader reader = JsonReader.of(source);
-	    reader.beginObject();
-        while(reader.hasNext()) {
+        // too many parameters
+        try {
+            BoundParameterQuery query = QueryBuilder.newQuery("SELECT * FROM abc WHERE a > $abc")
+                    .forDatabase("foobar")
+                    .bind("abc", 0)
+                    .bind("bcd", 10)
+                    .create();
+            query.getParameterJsonWithUrlEncoded();
+            Assert.fail("Expected RuntimeException because of unbalanced placeholders and parameters");
+        } catch (RuntimeException rte) {
+            // expected
+        }
+    }
+
+    private Map<String, Object> readObject(String json) throws IOException {
+        Buffer source = new Buffer();
+        source.writeString(json, Charset.forName("utf-8"));
+        Map<String, Object> params = new HashMap<>();
+        JsonReader reader = JsonReader.of(source);
+        reader.beginObject();
+        while (reader.hasNext()) {
             String name = reader.nextName();
             Object value = reader.readJsonValue();
             params.put(name, value);
         }
-	    reader.endObject();
-	    return params;
-	}
+        reader.endObject();
+        return params;
+    }
 
-	private static String decode(String str) throws UnsupportedEncodingException {
+    private static String decode(String str) throws UnsupportedEncodingException {
         return URLDecoder.decode(str, StandardCharsets.UTF_8.toString());
     }
 }


### PR DESCRIPTION
This is a simple implementation for "prepared statements" (influxdata/influxdb-java#274) using regular expressions.

I added a new query class BoundParameterQuery, which can be used for
"prepared statements". The constructor accepts an InfluxQL expression
with placeholders, a DB name and a varags list to bind the parameters to
the placeholders. I also extended the InfluxDBService, so that the HTTP
requests contain the "params" parameter. The InfluxDBImpl now
differentiates between a Query and a BoundParameterQuery. This is not
the cleanest solution, because this had to be done at a few locations,
but I didn't want to change too much of the code.

It has limitations, because it does not use a parser/grammar for InfluxQL. So you could for example have a placeholder in a string value of a field/tag and this implementation would fail, but at least it is a start and better than risking injections.

Feel free to delete this pull request, if you don't like it at all ;)