### PR TITLE
allow to figure out, whether the Point.Builder has any fields

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -188,6 +188,15 @@ public class Point {
     }
 
     /**
+     * Does this builder contain any fields?
+     *
+     * @return true, if the builder contains any fields, false otherwise.
+     */
+    public boolean hasFields() {
+      return !fields.isEmpty();
+    }
+
+    /**
      * Create a new Point.
      *
      * @return the newly created Point.

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -330,4 +330,13 @@ public class PointTest {
 		// THEN equals returns true
 		assertThat(equals).isEqualTo(false);
 	}
+
+	@Test
+	public void testBuilderHasFields() {
+		Point.Builder pointBuilder = Point.measurement("nulltest").time(1, TimeUnit.NANOSECONDS).tag("foo", "bar");
+		assertThat(pointBuilder.hasFields()).isFalse();
+
+		pointBuilder.addField("testfield", 256);
+		assertThat(pointBuilder.hasFields()).isTrue();
+	}
 }


### PR DESCRIPTION
since the build mehtod contains validation for fields emptiness, there should be also way, how to figure out, whether the Builder contains any fields (to prevent the build method from throwing an exception)