### PR TITLE
Speedup travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
+language: java
+
 sudo: required
 
 services:
   - docker
 
+# We test against all influxdb versions with the most actual JDK.
+# Test only the most recent influxdb version with JDK8 which will be legacy soon.
 env:
-  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.5
-  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.4
-  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.3
-  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.2
-  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.1
   - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.5
   - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.4
   - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.3
   - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.2
   - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.1
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.5
 
 script: ./compile-and-test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
-language: java
 sudo: required
-
-jdk:
-  - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer # Updates JDK 8 to the latest available.
 
 services:
   - docker
+
+env:
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.5
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.4
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.3
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.2
+  - MAVEN_JAVA_VERSION=3-jdk-8-slim INFLUXDB_VERSION=1.1
+  - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.5
+  - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.4
+  - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.3
+  - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.2
+  - MAVEN_JAVA_VERSION=3-jdk-10-slim INFLUXDB_VERSION=1.1
+
 script: ./compile-and-test.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: java
-
 sudo: required
 
 services:

--- a/compile-and-test.sh
+++ b/compile-and-test.sh
@@ -4,36 +4,31 @@
 #
 set -e
 
-INFLUXDB_VERSIONS="1.5 1.4 1.3 1.2 1.1"
+DEFAULT_INFLUXDB_VERSION="1.5"
+DEFAULT_MAVEN_JAVA_VERSION="3-jdk-10-slim"
 
-JAVA_VERSIONS="3-jdk-8-alpine 3-jdk-10-slim"
+INFLUXDB_VERSION="${INFLUXDB_VERSION:-$DEFAULT_INFLUXDB_VERSION}"
+MAVEN_JAVA_VERSION="${MAVEN_JAVA_VERSION:-$DEFAULT_MAVEN_JAVA_VERSION}"
 
+echo "Run tests with maven:${MAVEN_JAVA_VERSION} on onfluxdb-${INFLUXDB_VERSION}"
 
-for java_version in ${JAVA_VERSIONS}
-do
- echo "Run tests with maven:${java_version}"
-for version in ${INFLUXDB_VERSIONS}
-do
-  echo "Tesing againts influxdb ${version}"
-  docker kill influxdb || true
-  docker rm influxdb || true
-  docker pull influxdb:${version}-alpine || true
-  docker run \
-            --detach \
-            --name influxdb \
-            --publish 8086:8086 \
-            --publish 8089:8089/udp \
-            --volume ${PWD}/influxdb.conf:/etc/influxdb/influxdb.conf \
-        influxdb:${version}-alpine
+docker kill influxdb || true
+docker rm influxdb || true
+docker pull influxdb:${version}-alpine || true
+docker run \
+          --detach \
+          --name influxdb \
+          --publish 8086:8086 \
+          --publish 8089:8089/udp \
+          --volume ${PWD}/influxdb.conf:/etc/influxdb/influxdb.conf \
+      influxdb:${INFLUXDB_VERSION}-alpine
 
-  docker run -it --rm  \
-        --volume $PWD:/usr/src/mymaven \
-        --volume $PWD/.m2:/root/.m2 \
-        --workdir /usr/src/mymaven \
-        --link=influxdb \
-        --env INFLUXDB_IP=influxdb \
-         maven:${java_version} mvn clean install
+docker run -it --rm  \
+      --volume $PWD:/usr/src/mymaven \
+      --volume $PWD/.m2:/root/.m2 \
+      --workdir /usr/src/mymaven \
+      --link=influxdb \
+      --env INFLUXDB_IP=influxdb \
+        maven:${MAVEN_JAVA_VERSION} mvn clean install
 
-  docker kill influxdb || true
-done
-done
+docker kill influxdb || true

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/org/influxdb/PerformanceTests.java
+++ b/src/test/java/org/influxdb/PerformanceTests.java
@@ -171,11 +171,11 @@ public class PerformanceTests {
       }
     };
     
-    answer.params.put("startTime", System.currentTimeMillis() + 80000);
+    answer.params.put("startTime", System.currentTimeMillis() + 8000);
     doAnswer(answer).when(spy).write(any(BatchPoints.class));
     
     spy.createDatabase(dbName);
-    BatchOptions batchOptions = BatchOptions.DEFAULTS.actions(100000).flushDuration(20000).bufferLimit(3000000).exceptionHandler((points, throwable) -> {
+    BatchOptions batchOptions = BatchOptions.DEFAULTS.actions(10000).flushDuration(2000).bufferLimit(300000).exceptionHandler((points, throwable) -> {
       System.out.println("+++++++++++ exceptionHandler +++++++++++");
       System.out.println(throwable);
       System.out.println("++++++++++++++++++++++++++++++++++++++++");
@@ -185,17 +185,17 @@ public class PerformanceTests {
     spy.enableBatch(batchOptions);
     String rp = TestUtils.defaultRetentionPolicy(spy.version());
 
-    for (long i = 0; i < 400000; i++) {
+    for (long i = 0; i < 40000; i++) {
       Point point = Point.measurement("s").time(i, TimeUnit.MILLISECONDS).addField("v", 1.0).build();
       spy.write(dbName, rp, point);
     }
     
     System.out.println("sleep");
-    Thread.sleep(120000);
+    Thread.sleep(12000);
     try {
       QueryResult result = spy.query(new Query("select count(v) from s", dbName));
       double d = Double.parseDouble(result.getResults().get(0).getSeries().get(0).getValues().get(0).get(1).toString());
-      Assertions.assertEquals(400000, d);
+      Assertions.assertEquals(40000, d);
     } catch (Exception e) {
       System.out.println("+++++++++++++++++count() +++++++++++++++++++++");
       System.out.println(e);


### PR DESCRIPTION
Build should always be as fast as possible. so i did:

- create a travis matrix of JDK and Influxdb version
- run test against all influxdb versions only with the most current JDK, test with JDK8 only influxdb 1.5
- reduce the amount of points written in one particular Performancetest.

Total duration is now ~3min compared to 35min before.

