### PR TITLE
Adding wait time for writing a point to the DB

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -284,6 +284,20 @@ public interface InfluxDB {
   public void write(final String database, final String retentionPolicy, final Point point);
 
   /**
+   * Write a single Point to the database by waiting for specified time for space to become available.
+   *
+   * @param database
+   *            the database to write to.
+   * @param retentionPolicy
+   *            the retentionPolicy to use.
+   * @param point
+   *            The point to write
+   * @param timeout
+   *            How long to wait in seconds
+   */
+  public void write(final String database, final String retentionPolicy, final Point point, final long timeout);
+
+  /**
    * Write a single Point to the database through UDP.
    *
    * @param udpPort

--- a/src/main/java/org/influxdb/impl/BatchProcessor.java
+++ b/src/main/java/org/influxdb/impl/BatchProcessor.java
@@ -354,6 +354,22 @@ public final class BatchProcessor {
     }
   }
 
+  void put(final AbstractBatchEntry batchEntry, final long timeout) {
+    try {
+      this.queue.offer(batchEntry, timeout, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    if (this.queue.size() >= this.actions) {
+      this.scheduler.submit(new Runnable() {
+        @Override
+        public void run() {
+          write();
+        }
+      });
+    }
+  }
+
   /**
    * Flush the current open writes to influxdb and end stop the reaper thread. This should only be
    * called if no batch processing is needed anymore.


### PR DESCRIPTION
We've been facing a problem in production for a pretty widely used product. BatchProcessor is currently using a BlockingQueue. There have been times when writing to this queue has blocked our main thread while writing a metric into the queue.

I'm trying to address that issue through this PR by using offer() with a timeout instead of put. This will allow us to simply drop that data point if its taking too long instead of blocking the main thread.