### PR TITLE
Implement Issue #389 : Support for MessagePack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Support dynamic measurement name in InfluxDBResultMapper [PR #423](https://github.com/influxdata/influxdb-java/pull/423)
 - Debug mode which allows HTTP requests being sent to the database to be logged [PR #450](https://github.com/influxdata/influxdb-java/pull/450)
 - Fix problem of connecting to the influx api with URL which does not points to the url root (e.g. localhots:80/influx-api/) [PR #400] (https://github.com/influxdata/influxdb-java/pull/400)
+- Support for MessagePack [PR #462] (https://github.com/influxdata/influxdb-java/pull/462)
+   - This PR basically improves the query performance by approximately 20%
 
 ## 2.10 [2018-04-26]
 

--- a/compile-and-test.sh
+++ b/compile-and-test.sh
@@ -45,6 +45,7 @@ docker run -it --rm  \
       --workdir /usr/src/mymaven \
    --link=influxdb \
    --link=nginx \
+   --env INFLUXDB_VERSION=${INFLUXDB_VERSION} \
    --env INFLUXDB_IP=influxdb \
    --env PROXY_API_URL=$PROXY_API_URL \
    --env PROXY_UDP_PORT=$PROXY_UDP_PORT \

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,11 @@
       <artifactId>converter-moshi</artifactId>
       <version>2.4.0</version>
     </dependency>
+    <dependency>
+    <groupId>org.komamitsu</groupId>
+      <artifactId>retrofit-converter-msgpack</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <!-- If we use okhttp instead of java urlconnection we achieve server failover
             of the influxdb server address resolves to all influxdb server ips. -->
     <dependency>

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -95,6 +95,15 @@ public interface InfluxDB {
   }
 
   /**
+   * Format of HTTP Response body from InfluxDB server.
+   */
+  public enum ResponseFormat {
+    /** application/json format. */
+    JSON,
+    /** application/x-msgpack format. */
+    MSGPACK
+  }
+  /**
    * Set the loglevel which is used for REST related actions.
    *
    * @param logLevel

--- a/src/main/java/org/influxdb/InfluxDBFactory.java
+++ b/src/main/java/org/influxdb/InfluxDBFactory.java
@@ -1,5 +1,6 @@
 package org.influxdb;
 
+import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.impl.InfluxDBImpl;
 
 import okhttp3.OkHttpClient;
@@ -78,7 +79,7 @@ public enum InfluxDBFactory {
    */
   public static InfluxDB connect(final String url, final String username, final String password,
       final OkHttpClient.Builder client) {
-    return connect(url, username, password, client, false);
+    return connect(url, username, password, client, ResponseFormat.JSON);
   }
 
   /**
@@ -93,15 +94,15 @@ public enum InfluxDBFactory {
    *            instance.
    * @param client
    *            the HTTP client to use
-   * @param useMsgPack
-   *            Accept MessagePack format (TRUE) or JSon (FALSE) for response from InfluxDB server
+   * @param responseFormat
+   *            The {@code ResponseFormat} to use for response from InfluxDB server
    * @return a InfluxDB adapter suitable to access a InfluxDB.
    */
   public static InfluxDB connect(final String url, final String username, final String password,
-      final OkHttpClient.Builder client, final boolean useMsgPack) {
+      final OkHttpClient.Builder client, final ResponseFormat responseFormat) {
     Preconditions.checkNonEmptyString(url, "url");
     Preconditions.checkNonEmptyString(username, "username");
     Objects.requireNonNull(client, "client");
-    return new InfluxDBImpl(url, username, password, client, useMsgPack);
+    return new InfluxDBImpl(url, username, password, client, responseFormat);
   }
 }

--- a/src/main/java/org/influxdb/InfluxDBFactory.java
+++ b/src/main/java/org/influxdb/InfluxDBFactory.java
@@ -78,9 +78,30 @@ public enum InfluxDBFactory {
    */
   public static InfluxDB connect(final String url, final String username, final String password,
       final OkHttpClient.Builder client) {
+    return connect(url, username, password, client, false);
+  }
+
+  /**
+   * Create a connection to a InfluxDB.
+   *
+   * @param url
+   *            the url to connect to.
+   * @param username
+   *            the username which is used to authorize against the influxDB instance.
+   * @param password
+   *            the password for the username which is used to authorize against the influxDB
+   *            instance.
+   * @param client
+   *            the HTTP client to use
+   * @param useMsgPack
+   *            Accept MessagePack format (TRUE) or JSon (FALSE) for response from InfluxDB server
+   * @return a InfluxDB adapter suitable to access a InfluxDB.
+   */
+  public static InfluxDB connect(final String url, final String username, final String password,
+      final OkHttpClient.Builder client, final boolean useMsgPack) {
     Preconditions.checkNonEmptyString(url, "url");
     Preconditions.checkNonEmptyString(username, "username");
     Objects.requireNonNull(client, "client");
-    return new InfluxDBImpl(url, username, password, client);
+    return new InfluxDBImpl(url, username, password, client, useMsgPack);
   }
 }

--- a/src/main/java/org/influxdb/dto/QueryResult.java
+++ b/src/main/java/org/influxdb/dto/QueryResult.java
@@ -3,6 +3,8 @@ package org.influxdb.dto;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * {Purpose of This Type}.
  *
@@ -68,9 +70,19 @@ public class QueryResult {
     this.error = error;
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Result {
+    private List<Abc> abc;
     private List<Series> series;
     private String error;
+
+    public List<Abc> getAbc() {
+      return abc;
+    }
+
+    public void setAbc(final List<Abc> abc) {
+      this.abc = abc;
+    }
 
     /**
      * @return the series
@@ -128,6 +140,93 @@ public class QueryResult {
 
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class Abc {
+    private String name;
+    private Map<String, String> tags;
+    private List<String> columns;
+    private List<List<Object>> values;
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+      return this.name;
+    }
+
+    /**
+     * @param name
+     *            the name to set
+     */
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    /**
+     * @return the tags
+     */
+    public Map<String, String> getTags() {
+      return this.tags;
+    }
+
+    /**
+     * @param tags
+     *            the tags to set
+     */
+    public void setTags(final Map<String, String> tags) {
+      this.tags = tags;
+    }
+
+    /**
+     * @return the columns
+     */
+    public List<String> getColumns() {
+      return this.columns;
+    }
+
+    /**
+     * @param columns
+     *            the columns to set
+     */
+    public void setColumns(final List<String> columns) {
+      this.columns = columns;
+    }
+
+    /**
+     * @return the values
+     */
+    public List<List<Object>> getValues() {
+      return this.values;
+    }
+
+    /**
+     * @param values
+     *            the values to set
+     */
+    public void setValues(final List<List<Object>> values) {
+      this.values = values;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Series [name=");
+      builder.append(this.name);
+      builder.append(", tags=");
+      builder.append(this.tags);
+      builder.append(", columns=");
+      builder.append(this.columns);
+      builder.append(", values=");
+      builder.append(this.values);
+      builder.append("]");
+      return builder.toString();
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Series {
     private String name;
     private Map<String, String> tags;

--- a/src/main/java/org/influxdb/dto/QueryResult.java
+++ b/src/main/java/org/influxdb/dto/QueryResult.java
@@ -72,17 +72,8 @@ public class QueryResult {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Result {
-    private List<Abc> abc;
     private List<Series> series;
     private String error;
-
-    public List<Abc> getAbc() {
-      return abc;
-    }
-
-    public void setAbc(final List<Abc> abc) {
-      this.abc = abc;
-    }
 
     /**
      * @return the series
@@ -138,92 +129,6 @@ public class QueryResult {
       return builder.toString();
     }
 
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public static class Abc {
-    private String name;
-    private Map<String, String> tags;
-    private List<String> columns;
-    private List<List<Object>> values;
-
-    /**
-     * @return the name
-     */
-    public String getName() {
-      return this.name;
-    }
-
-    /**
-     * @param name
-     *            the name to set
-     */
-    public void setName(final String name) {
-      this.name = name;
-    }
-
-    /**
-     * @return the tags
-     */
-    public Map<String, String> getTags() {
-      return this.tags;
-    }
-
-    /**
-     * @param tags
-     *            the tags to set
-     */
-    public void setTags(final Map<String, String> tags) {
-      this.tags = tags;
-    }
-
-    /**
-     * @return the columns
-     */
-    public List<String> getColumns() {
-      return this.columns;
-    }
-
-    /**
-     * @param columns
-     *            the columns to set
-     */
-    public void setColumns(final List<String> columns) {
-      this.columns = columns;
-    }
-
-    /**
-     * @return the values
-     */
-    public List<List<Object>> getValues() {
-      return this.values;
-    }
-
-    /**
-     * @param values
-     *            the values to set
-     */
-    public void setValues(final List<List<Object>> values) {
-      this.values = values;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-      StringBuilder builder = new StringBuilder();
-      builder.append("Series [name=");
-      builder.append(this.name);
-      builder.append(", tags=");
-      builder.append(this.tags);
-      builder.append(", columns=");
-      builder.append(this.columns);
-      builder.append(", values=");
-      builder.append(this.values);
-      builder.append("]");
-      return builder.toString();
-    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/influxdb/dto/QueryResult.java
+++ b/src/main/java/org/influxdb/dto/QueryResult.java
@@ -3,8 +3,6 @@ package org.influxdb.dto;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 /**
  * {Purpose of This Type}.
  *
@@ -70,7 +68,6 @@ public class QueryResult {
     this.error = error;
   }
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Result {
     private List<Series> series;
     private String error;
@@ -131,7 +128,6 @@ public class QueryResult {
 
   }
 
-  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Series {
     private String name;
     private Map<String, String> tags;

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -177,6 +177,15 @@ public class InfluxDBImpl implements InfluxDB {
         .build();
     this.influxDBService = this.retrofit.create(InfluxDBService.class);
 
+    if (ResponseFormat.MSGPACK.equals(responseFormat)) {
+      String[] versionNumbers = version().split("\\.");
+      final int major = Integer.parseInt(versionNumbers[0]);
+      final int minor = Integer.parseInt(versionNumbers[1]);
+      final int fromMinor = 4;
+      if ((major < 2) && ((major != 1) || (minor < fromMinor))) {
+        throw new InfluxDBException("MessagePack format is only supported from InfluxDB version 1.4 and later");
+      }
+    }
   }
 
   public InfluxDBImpl(final String url, final String username, final String password,

--- a/src/test/java/org/influxdb/BatchOptionsTest.java
+++ b/src/test/java/org/influxdb/BatchOptionsTest.java
@@ -6,6 +6,7 @@ import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
+import org.influxdb.dto.QueryResult.Series;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -130,7 +132,8 @@ public class BatchOptionsTest {
       
       //check no points writen to DB before the flush duration
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      Assertions.assertNull(result.getResults().get(0).getSeries());
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series == null || series.isEmpty());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       //wait for at least one flush
@@ -164,7 +167,8 @@ public class BatchOptionsTest {
       Thread.sleep(100);
       
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      Assertions.assertNull(result.getResults().get(0).getSeries());
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series == null || series.isEmpty());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       //wait for at least one flush
@@ -231,7 +235,8 @@ public class BatchOptionsTest {
       
       QueryResult result = spy.query(new Query("select * from weather", dbName));
       //assert 0 point written because of InfluxDBException and OneShotBatchWriter did not retry
-      Assertions.assertNull(result.getResults().get(0).getSeries());
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series == null || series.isEmpty());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       answer.params.put("throwException", false);
@@ -290,7 +295,8 @@ public class BatchOptionsTest {
       
       QueryResult result = spy.query(new Query("select * from measurement1", dbName));
       //assert 0 point written because of non-retry capable DATABASE_NOT_FOUND_ERROR and RetryCapableBatchWriter did not retry
-      Assertions.assertNull(result.getResults().get(0).getSeries());
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series == null || series.isEmpty());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       writeSomePoints(spy, "measurement2", 0, 5);
@@ -382,7 +388,8 @@ public class BatchOptionsTest {
       verify(mockHandler, times(1)).accept(any(), any());
       
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      Assertions.assertNull(result.getResults().get(0).getSeries());
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series == null || series.isEmpty());
       Assertions.assertNull(result.getResults().get(0).getError());
     } finally {
       spy.disableBatch();

--- a/src/test/java/org/influxdb/BatchOptionsTest.java
+++ b/src/test/java/org/influxdb/BatchOptionsTest.java
@@ -6,7 +6,6 @@ import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.influxdb.dto.QueryResult.Series;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -29,7 +27,7 @@ import java.util.function.BiConsumer;
 @RunWith(JUnitPlatform.class)
 public class BatchOptionsTest {
 
-  private InfluxDB influxDB;
+  InfluxDB influxDB;
 
   @BeforeEach
   public void setUp() throws InterruptedException, IOException {
@@ -132,8 +130,7 @@ public class BatchOptionsTest {
       
       //check no points writen to DB before the flush duration
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      List<Series> series = result.getResults().get(0).getSeries();
-      Assertions.assertTrue(series == null || series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getSeries());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       //wait for at least one flush
@@ -167,8 +164,7 @@ public class BatchOptionsTest {
       Thread.sleep(100);
       
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      List<Series> series = result.getResults().get(0).getSeries();
-      Assertions.assertTrue(series == null || series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getSeries());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       //wait for at least one flush
@@ -235,8 +231,7 @@ public class BatchOptionsTest {
       
       QueryResult result = spy.query(new Query("select * from weather", dbName));
       //assert 0 point written because of InfluxDBException and OneShotBatchWriter did not retry
-      List<Series> series = result.getResults().get(0).getSeries();
-      Assertions.assertTrue(series == null || series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getSeries());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       answer.params.put("throwException", false);
@@ -295,8 +290,7 @@ public class BatchOptionsTest {
       
       QueryResult result = spy.query(new Query("select * from measurement1", dbName));
       //assert 0 point written because of non-retry capable DATABASE_NOT_FOUND_ERROR and RetryCapableBatchWriter did not retry
-      List<Series> series = result.getResults().get(0).getSeries();
-      Assertions.assertTrue(series == null || series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getSeries());
       Assertions.assertNull(result.getResults().get(0).getError());
       
       writeSomePoints(spy, "measurement2", 0, 5);
@@ -388,8 +382,7 @@ public class BatchOptionsTest {
       verify(mockHandler, times(1)).accept(any(), any());
       
       QueryResult result = influxDB.query(new Query("select * from weather", dbName));
-      List<Series> series = result.getResults().get(0).getSeries();
-      Assertions.assertTrue(series == null || series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getSeries());
       Assertions.assertNull(result.getResults().get(0).getError());
     } finally {
       spy.disableBatch();
@@ -492,7 +485,7 @@ public class BatchOptionsTest {
     }
   }
   
-  private void writeSomePoints(InfluxDB influxDB, String measurement, int firstIndex, int lastIndex) {
+  void writeSomePoints(InfluxDB influxDB, String measurement, int firstIndex, int lastIndex) {
     for (int i = firstIndex; i <= lastIndex; i++) {
       Point point = Point.measurement(measurement)
               .time(i,TimeUnit.HOURS)
@@ -503,7 +496,7 @@ public class BatchOptionsTest {
     }
   }
   
-  private void writeSomePoints(InfluxDB influxDB, int firstIndex, int lastIndex) {
+  void writeSomePoints(InfluxDB influxDB, int firstIndex, int lastIndex) {
     for (int i = firstIndex; i <= lastIndex; i++) {
       Point point = Point.measurement("weather")
               .time(i,TimeUnit.HOURS)
@@ -514,15 +507,15 @@ public class BatchOptionsTest {
     }
   }
   
-  private void write20Points(InfluxDB influxDB) {
+  void write20Points(InfluxDB influxDB) {
     writeSomePoints(influxDB, 0, 19);
   }
   
-  private void writeSomePoints(InfluxDB influxDB, int n) {
+  void writeSomePoints(InfluxDB influxDB, int n) {
     writeSomePoints(influxDB, 0, n - 1);
   }
   
-  private static String createErrorBody(String errorMessage) {
+  static String createErrorBody(String errorMessage) {
     return MessageFormat.format("'{' \"error\": \"{0}\" '}'", errorMessage);
   }
 }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -1,6 +1,7 @@
 package org.influxdb;
 
 import org.influxdb.InfluxDB.LogLevel;
+import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.BoundParameterQuery.QueryBuilder;
 import org.influxdb.dto.Point;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 
@@ -877,4 +879,16 @@ public class InfluxDBTest {
 				}, InfluxDB.ConsistencyLevel.ALL);
 		Assertions.assertTrue(this.influxDB.isBatchEnabled());
 	}
+
+	/**
+   * Test initialize InfluxDBImpl with MessagePack format for InfluxDB versions before 1.4 will throw exception
+   */
+	@Test
+	@EnabledIfEnvironmentVariable(named = "INFLUXDB_VERSION", matches = "1\\.3|1\\.2|1\\.1")
+	public void testMessagePackOnOldDbVersion() {
+	  Assertions.assertThrows(InfluxDBException.class, () -> {
+	    TestUtils.connectToInfluxDB(ResponseFormat.MSGPACK);
+	  });
+	}
+	
 }

--- a/src/test/java/org/influxdb/MessagePackBatchOptionsTest.java
+++ b/src/test/java/org/influxdb/MessagePackBatchOptionsTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.BiConsumer;
 
+import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.InfluxDBException.DatabaseNotFoundException;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
@@ -40,7 +41,7 @@ public class MessagePackBatchOptionsTest extends BatchOptionsTest {
   @Override
   @BeforeEach
   public void setUp() throws InterruptedException, IOException {
-    influxDB = TestUtils.connectToInfluxDB(true);
+    influxDB = TestUtils.connectToInfluxDB(ResponseFormat.MSGPACK);
   }
 
   /**

--- a/src/test/java/org/influxdb/MessagePackBatchOptionsTest.java
+++ b/src/test/java/org/influxdb/MessagePackBatchOptionsTest.java
@@ -1,0 +1,270 @@
+package org.influxdb;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import org.influxdb.InfluxDBException.DatabaseNotFoundException;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.influxdb.dto.QueryResult.Series;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Test the InfluxDB API over MessagePack format
+ *
+ * @author hoan.le [at] bonitoo.io
+ *
+ */
+@RunWith(JUnitPlatform.class)
+@EnabledIfEnvironmentVariable(named = "INFLUXDB_VERSION", matches = "1\\.5|1\\.4")
+public class MessagePackBatchOptionsTest extends BatchOptionsTest {
+
+  @Override
+  @BeforeEach
+  public void setUp() throws InterruptedException, IOException {
+    influxDB = TestUtils.connectToInfluxDB(true);
+  }
+
+  /**
+   * Test the implementation of {@link BatchOptions#flushDuration(int)} }.
+   * 
+   * @throws InterruptedException
+   */
+  @Override
+  @Test
+  public void testFlushDuration() throws InterruptedException {
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    try {
+      BatchOptions options = BatchOptions.DEFAULTS.flushDuration(200);
+      influxDB.createDatabase(dbName);
+      influxDB.setDatabase(dbName);
+      influxDB.enableBatch(options);
+      write20Points(influxDB);
+
+      // check no points writen to DB before the flush duration
+      QueryResult result = influxDB.query(new Query("select * from weather", dbName));
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getError());
+
+      // wait for at least one flush
+      Thread.sleep(500);
+      result = influxDB.query(new Query("select * from weather", dbName));
+
+      // check points written already to DB
+      Assertions.assertEquals(20, result.getResults().get(0).getSeries().get(0).getValues().size());
+    } finally {
+      this.influxDB.disableBatch();
+      this.influxDB.deleteDatabase(dbName);
+    }
+  }
+
+  /**
+   * Test the implementation of {@link BatchOptions#jitterDuration(int)} }.
+   * 
+   * @throws InterruptedException
+   */
+  @Override
+  @Test
+  public void testJitterDuration() throws InterruptedException {
+
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    try {
+      BatchOptions options = BatchOptions.DEFAULTS.flushDuration(100).jitterDuration(500);
+      influxDB.createDatabase(dbName);
+      influxDB.setDatabase(dbName);
+      influxDB.enableBatch(options);
+      write20Points(influxDB);
+
+      Thread.sleep(100);
+
+      QueryResult result = influxDB.query(new Query("select * from weather", dbName));
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getError());
+
+      // wait for at least one flush
+      Thread.sleep(1000);
+      result = influxDB.query(new Query("select * from weather", dbName));
+      Assertions.assertEquals(20, result.getResults().get(0).getSeries().get(0).getValues().size());
+    } finally {
+      influxDB.disableBatch();
+      influxDB.deleteDatabase(dbName);
+    }
+  }
+
+  /**
+   * Test the implementation of {@link BatchOptions#bufferLimit(int)} }. use a
+   * bufferLimit that less than actions, then OneShotBatchWrite is used
+   */
+  @Override
+  @Test
+  public void testBufferLimitLessThanActions() throws InterruptedException {
+
+    TestAnswer answer = new TestAnswer() {
+
+      InfluxDBException influxDBException = InfluxDBException
+          .buildExceptionForErrorState(createErrorBody(InfluxDBException.CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR));
+
+      @Override
+      protected void check(InvocationOnMock invocation) {
+        if ((Boolean) params.get("throwException")) {
+          throw influxDBException;
+        }
+      }
+    };
+
+    InfluxDB spy = spy(influxDB);
+    // the spied influxDB.write(BatchPoints) will always throw InfluxDBException
+    doAnswer(answer).when(spy).write(any(BatchPoints.class));
+
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    try {
+      answer.params.put("throwException", true);
+      BiConsumer<Iterable<Point>, Throwable> mockHandler = mock(BiConsumer.class);
+      BatchOptions options = BatchOptions.DEFAULTS.bufferLimit(3).actions(4).flushDuration(100)
+          .exceptionHandler(mockHandler);
+
+      spy.createDatabase(dbName);
+      spy.setDatabase(dbName);
+      spy.enableBatch(options);
+      write20Points(spy);
+
+      Thread.sleep(300);
+      verify(mockHandler, atLeastOnce()).accept(any(), any());
+
+      QueryResult result = spy.query(new Query("select * from weather", dbName));
+      // assert 0 point written because of InfluxDBException and
+      // OneShotBatchWriter did not retry
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getError());
+
+      answer.params.put("throwException", false);
+      write20Points(spy);
+      Thread.sleep(300);
+      result = spy.query(new Query("select * from weather", dbName));
+      // assert all 20 points written to DB due to no exception
+      Assertions.assertEquals(20, result.getResults().get(0).getSeries().get(0).getValues().size());
+    } finally {
+      spy.disableBatch();
+      spy.deleteDatabase(dbName);
+    }
+  }
+  
+  /**
+   * Test the implementation of {@link BatchOptions#bufferLimit(int)} }.
+   * use a bufferLimit that greater than actions, then RetryCapableBatchWriter is used
+   */
+  @Override
+  @Test
+  public void testBufferLimitGreaterThanActions() throws InterruptedException {
+    TestAnswer answer = new TestAnswer() {
+      
+      int nthCall = 0;
+      InfluxDBException cacheMaxMemorySizeExceededException = InfluxDBException.buildExceptionForErrorState(createErrorBody(InfluxDBException.CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR)); 
+      @Override
+      protected void check(InvocationOnMock invocation) {
+        
+        switch (nthCall++) {
+        case 0:
+          throw InfluxDBException.buildExceptionForErrorState(createErrorBody(InfluxDBException.DATABASE_NOT_FOUND_ERROR));
+        case 1:
+          throw InfluxDBException.buildExceptionForErrorState(createErrorBody(InfluxDBException.CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR));
+        default:
+          break;
+        }
+      }
+    };
+
+    InfluxDB spy = spy(influxDB);
+    doAnswer(answer).when(spy).write(any(BatchPoints.class));
+    
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    try {
+      BiConsumer<Iterable<Point>, Throwable> mockHandler = mock(BiConsumer.class);
+      BatchOptions options = BatchOptions.DEFAULTS.bufferLimit(10).actions(8).flushDuration(100).exceptionHandler(mockHandler);
+
+      spy.createDatabase(dbName);
+      spy.setDatabase(dbName);
+      spy.enableBatch(options);
+      writeSomePoints(spy, "measurement1", 0, 5);
+      
+      Thread.sleep(300);
+      verify(mockHandler, atLeastOnce()).accept(any(), any());
+      
+      QueryResult result = spy.query(new Query("select * from measurement1", dbName));
+      //assert 0 point written because of non-retry capable DATABASE_NOT_FOUND_ERROR and RetryCapableBatchWriter did not retry
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getError());
+      
+      writeSomePoints(spy, "measurement2", 0, 5);
+      
+      Thread.sleep(300);
+      
+      result = spy.query(new Query("select * from measurement2", dbName));
+      //assert all 6 point written because of retry capable CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR and RetryCapableBatchWriter did retry
+      Assertions.assertEquals(6, result.getResults().get(0).getSeries().get(0).getValues().size());
+    }
+    finally {
+      spy.disableBatch();
+      spy.deleteDatabase(dbName);
+    }
+  }
+  
+  
+  /**
+   * Test the implementation of {@link BatchOptions#exceptionHandler(BiConsumer)} }.
+   * @throws InterruptedException
+   */
+  @Override
+  @Test
+  public void testHandlerOnRetryImpossible() throws InterruptedException {
+    
+    String dbName = "write_unittest_" + System.currentTimeMillis();
+    InfluxDB spy = spy(influxDB);
+    doThrow(DatabaseNotFoundException.class).when(spy).write(any(BatchPoints.class));
+    
+    try {
+      BiConsumer<Iterable<Point>, Throwable> mockHandler = mock(BiConsumer.class);
+      BatchOptions options = BatchOptions.DEFAULTS.exceptionHandler(mockHandler).flushDuration(100);
+
+      spy.createDatabase(dbName);
+      spy.setDatabase(dbName);
+      spy.enableBatch(options);
+      
+      writeSomePoints(spy, 1);
+      
+      Thread.sleep(200);
+      verify(mockHandler, times(1)).accept(any(), any());
+      
+      QueryResult result = influxDB.query(new Query("select * from weather", dbName));
+      List<Series> series = result.getResults().get(0).getSeries();
+      Assertions.assertTrue(series.isEmpty());
+      Assertions.assertNull(result.getResults().get(0).getError());
+    } finally {
+      spy.disableBatch();
+      spy.deleteDatabase(dbName);
+    }
+    
+  }
+}

--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -1,0 +1,188 @@
+package org.influxdb;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the InfluxDB API over MessagePack format
+ *
+ * @author hoan.le [at] bonitoo.io
+ *
+ */
+@RunWith(JUnitPlatform.class)
+@EnabledIfEnvironmentVariable(named = "INFLUXDB_VERSION", matches = "1\\.5|1\\.4")
+public class MessagePackInfluxDBTest extends InfluxDBTest {
+  /**
+   * Create a influxDB connection before all tests start.
+   *
+   * @throws InterruptedException
+   * @throws IOException
+   */
+  @Override
+  @BeforeEach
+  public void setUp() throws InterruptedException, IOException {
+    influxDB = TestUtils.connectToInfluxDB(true);
+    influxDB.createDatabase(UDP_DATABASE);
+  }
+  
+  /**
+   * Tests writing points using the time precision feature
+   * @throws Exception
+   */
+  @Override
+  @Test
+  public void testWriteBatchWithPrecision() throws Exception {
+    // GIVEN a database and a measurement
+    String dbName = "precision_unittest_" + System.currentTimeMillis();
+    this.influxDB.createDatabase(dbName);
+
+    String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
+
+    String measurement = TestUtils.getRandomMeasurement();
+
+    long t1 = 1485273600;
+    Point p1 = Point
+        .measurement(measurement)
+        .addField("foo", 1d)
+        .tag("device", "one")
+        .time(t1, TimeUnit.SECONDS).build(); // 2017-01-27T16:00:00
+
+    long t2 = 1485277200;
+    Point p2 = Point
+        .measurement(measurement)
+        .addField("foo", 2d)
+        .tag("device", "two")
+        .time(t2, TimeUnit.SECONDS).build(); // 2017-01-27T17:00:00
+
+    long t3 = 1485280800;
+    Point p3 = Point
+        .measurement(measurement)
+        .addField("foo", 3d)
+        .tag("device", "three")
+        .time(t3, TimeUnit.SECONDS).build(); // 2017-01-27T18:00:00
+
+    BatchPoints batchPoints = BatchPoints
+        .database(dbName)
+        .retentionPolicy(rp)
+        .precision(TimeUnit.SECONDS)
+        .points(p1, p2, p3)
+        .build();
+
+    // WHEN I write the batch
+    this.influxDB.write(batchPoints);
+
+    // THEN the measure points have a timestamp with second precision
+    QueryResult queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName));
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0), t1);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0), t2);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0), t3);
+
+    this.influxDB.deleteDatabase(dbName);
+  }
+
+  @Override
+  @Test
+  public void testWriteBatchWithoutPrecision() throws Exception {
+    // GIVEN a database and a measurement
+    String dbName = "precision_unittest_" + System.currentTimeMillis();
+    this.influxDB.createDatabase(dbName);
+
+    String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
+
+    String measurement = TestUtils.getRandomMeasurement();
+
+    // GIVEN a batch of points that has no specific precision
+    long t1 = 1485273600000000100L;
+    Point p1 = Point
+        .measurement(measurement)
+        .addField("foo", 1d)
+        .tag("device", "one")
+        .time(t1, TimeUnit.NANOSECONDS).build(); // 2017-01-27T16:00:00.000000100Z
+    Double timeP1 = Double.valueOf(t1);
+
+    long t2 = 1485277200000000200L;
+    Point p2 = Point
+        .measurement(measurement)
+        .addField("foo", 2d)
+        .tag("device", "two")
+        .time(t2, TimeUnit.NANOSECONDS).build(); // 2017-01-27T17:00:00.000000200Z
+    Double timeP2 = Double.valueOf(t2);
+
+    long t3 = 1485280800000000300L;
+    Point p3 = Point
+        .measurement(measurement)
+        .addField("foo", 3d)
+        .tag("device", "three")
+        .time(t3, TimeUnit.NANOSECONDS).build(); // 2017-01-27T18:00:00.000000300Z
+    Double timeP3 = Double.valueOf(t3);
+
+    BatchPoints batchPoints = BatchPoints
+        .database(dbName)
+        .retentionPolicy(rp)
+        .points(p1, p2, p3)
+        .build();
+
+    // WHEN I write the batch
+    this.influxDB.write(batchPoints);
+
+    // THEN the measure points have a timestamp with second precision
+    QueryResult queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName), TimeUnit.NANOSECONDS);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().size(), 3);
+    Double value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0).toString());
+    Assertions.assertEquals(value, timeP1);
+    value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0).toString());
+    Assertions.assertEquals(value, timeP2);
+    value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0).toString());
+    Assertions.assertEquals(value, timeP3);
+
+    this.influxDB.deleteDatabase(dbName);
+  }
+  
+  @Override
+  @Test
+  public void testWriteRecordsWithPrecision() throws Exception {
+    // GIVEN a database and a measurement
+    String dbName = "precision_unittest_" + System.currentTimeMillis();
+    this.influxDB.createDatabase(dbName);
+
+    String rp = TestUtils.defaultRetentionPolicy(this.influxDB.version());
+
+    String measurement = TestUtils.getRandomMeasurement();
+    List<String> records = new ArrayList<>();
+    records.add(measurement + ",atag=test1 idle=100,usertime=10,system=1 1485273600");
+    long timeP1 = 1485273600;
+
+    records.add(measurement + ",atag=test2 idle=200,usertime=20,system=2 1485277200");
+    long timeP2 = 1485277200;
+
+    records.add(measurement + ",atag=test3 idle=300,usertime=30,system=3 1485280800");
+    long timeP3 = 1485280800;
+
+    // WHEN I write the batch
+    this.influxDB.write(dbName, rp, InfluxDB.ConsistencyLevel.ONE, TimeUnit.SECONDS, records);
+
+    // THEN the measure points have a timestamp with second precision
+    QueryResult queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName));
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().size(), 3);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0), timeP1);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0), timeP2);
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0), timeP3);
+    this.influxDB.deleteDatabase(dbName);
+  }
+}

--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.dto.BatchPoints;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
@@ -34,7 +35,7 @@ public class MessagePackInfluxDBTest extends InfluxDBTest {
   @Override
   @BeforeEach
   public void setUp() throws InterruptedException, IOException {
-    influxDB = TestUtils.connectToInfluxDB(true);
+    influxDB = TestUtils.connectToInfluxDB(ResponseFormat.MSGPACK);
     influxDB.createDatabase(UDP_DATABASE);
   }
   

--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -1,9 +1,6 @@
 package org.influxdb;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/org/influxdb/TestUtils.java
+++ b/src/test/java/org/influxdb/TestUtils.java
@@ -52,14 +52,18 @@ public class TestUtils {
   }
 
   public static InfluxDB connectToInfluxDB() throws InterruptedException, IOException {
-    return connectToInfluxDB(null, null);
+    return connectToInfluxDB(null, null, false);
   }
 
+  public static InfluxDB connectToInfluxDB(boolean useMsgPack) throws InterruptedException, IOException {
+    return connectToInfluxDB(null, null, useMsgPack);
+  }
   public static InfluxDB connectToInfluxDB(String apiUrl) throws InterruptedException, IOException {
-    return connectToInfluxDB(new OkHttpClient.Builder(), apiUrl);
+    return connectToInfluxDB(new OkHttpClient.Builder(), apiUrl, false);
   }
   
-  public static InfluxDB connectToInfluxDB(final OkHttpClient.Builder client, String apiUrl) throws InterruptedException, IOException {
+  public static InfluxDB connectToInfluxDB(final OkHttpClient.Builder client, String apiUrl,
+      boolean useMsgPack) throws InterruptedException, IOException {
     OkHttpClient.Builder clientToUse;
     if (client == null) {
       clientToUse = new OkHttpClient.Builder();
@@ -72,7 +76,7 @@ public class TestUtils {
     } else {
       apiUrlToUse = apiUrl;
     }
-    InfluxDB influxDB = InfluxDBFactory.connect(apiUrlToUse, "admin", "admin", clientToUse);
+    InfluxDB influxDB = InfluxDBFactory.connect(apiUrlToUse, "admin", "admin", clientToUse, useMsgPack);
     boolean influxDBstarted = false;
     do {
       Pong response;

--- a/src/test/java/org/influxdb/TestUtils.java
+++ b/src/test/java/org/influxdb/TestUtils.java
@@ -1,6 +1,8 @@
 package org.influxdb;
 
 import okhttp3.OkHttpClient;
+
+import org.influxdb.InfluxDB.ResponseFormat;
 import org.influxdb.dto.Pong;
 
 import java.io.IOException;
@@ -52,18 +54,18 @@ public class TestUtils {
   }
 
   public static InfluxDB connectToInfluxDB() throws InterruptedException, IOException {
-    return connectToInfluxDB(null, null, false);
+    return connectToInfluxDB(null, null, ResponseFormat.JSON);
   }
 
-  public static InfluxDB connectToInfluxDB(boolean useMsgPack) throws InterruptedException, IOException {
-    return connectToInfluxDB(null, null, useMsgPack);
+  public static InfluxDB connectToInfluxDB(ResponseFormat responseFormat) throws InterruptedException, IOException {
+    return connectToInfluxDB(null, null, responseFormat);
   }
   public static InfluxDB connectToInfluxDB(String apiUrl) throws InterruptedException, IOException {
-    return connectToInfluxDB(new OkHttpClient.Builder(), apiUrl, false);
+    return connectToInfluxDB(new OkHttpClient.Builder(), apiUrl, ResponseFormat.JSON);
   }
   
   public static InfluxDB connectToInfluxDB(final OkHttpClient.Builder client, String apiUrl,
-      boolean useMsgPack) throws InterruptedException, IOException {
+      ResponseFormat responseFormat) throws InterruptedException, IOException {
     OkHttpClient.Builder clientToUse;
     if (client == null) {
       clientToUse = new OkHttpClient.Builder();
@@ -76,7 +78,7 @@ public class TestUtils {
     } else {
       apiUrlToUse = apiUrl;
     }
-    InfluxDB influxDB = InfluxDBFactory.connect(apiUrlToUse, "admin", "admin", clientToUse, useMsgPack);
+    InfluxDB influxDB = InfluxDBFactory.connect(apiUrlToUse, "admin", "admin", clientToUse, responseFormat);
     boolean influxDBstarted = false;
     do {
       Pong response;


### PR DESCRIPTION
In comparison to PR #460 , this PR:
   + keep using Moshi for keep using Moshi for converting chunked response in JSON 
   + keep QueryResult neutral - do not put Jackson binding annotations on it

(please refer to this comment in PR #460 for more details: https://github.com/influxdata/influxdb-java/pull/460#issuecomment-397531836)