### PR TITLE
The InfluxDBResultMapper is able to handle results with a different time precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.13 [unreleased]
 
+### Fixes
+
+- The InfluxDBResultMapper is able to handle results with a different time precision [PR #501](https://github.com/influxdata/influxdb-java/pull/501)
+
 ### Features
 
 - Support for Basic Authentication [PR #492](https://github.com/influxdata/influxdb-java/pull/492)

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -202,7 +202,7 @@ public class InfluxDBResultMapper {
     });
   }
 
-  public void cacheMeasurementClass(final Class<?>... classVarAgrs) {
+  void cacheMeasurementClass(final Class<?>... classVarAgrs) {
     for (Class<?> clazz : classVarAgrs) {
       if (CLASS_FIELD_CACHE.containsKey(clazz.getName())) {
         continue;
@@ -222,12 +222,8 @@ public class InfluxDBResultMapper {
     }
   }
 
-  public String getMeasurementName(final Class<?> clazz) {
+  String getMeasurementName(final Class<?> clazz) {
     return ((Measurement) clazz.getAnnotation(Measurement.class)).name();
-  }
-
-  public <T> ConcurrentMap<String, Field> getColNameAndFieldMap(final Class<T> clazz) {
-    return CLASS_FIELD_CACHE.get(clazz.getName());
   }
 
   <T> List<T> parseSeriesAs(final QueryResult.Series series, final Class<T> clazz, final List<T> result) {
@@ -237,7 +233,7 @@ public class InfluxDBResultMapper {
   <T> List<T> parseSeriesAs(final QueryResult.Series series, final Class<T> clazz, final List<T> result,
                             final TimeUnit precision) {
     int columnSize = series.getColumns().size();
-    ConcurrentMap<String, Field> colNameAndFieldMap = getColNameAndFieldMap(clazz);
+    ConcurrentMap<String, Field> colNameAndFieldMap = CLASS_FIELD_CACHE.get(clazz.getName());
     try {
       T object = null;
       for (List<Object> row : series.getValues()) {
@@ -324,7 +320,7 @@ public class InfluxDBResultMapper {
       if (value instanceof String) {
         instant = Instant.from(ISO8601_FORMATTER.parse(String.valueOf(value)));
       } else if (value instanceof Long) {
-        instant = Instant.ofEpochMilli(toMillis((Long) value, precision));
+        instant = Instant.ofEpochMilli(toMillis((long) value, precision));
       } else if (value instanceof Double) {
         instant = Instant.ofEpochMilli(toMillis(((Double) value).longValue(), precision));
       } else if (value instanceof Integer) {
@@ -380,7 +376,7 @@ public class InfluxDBResultMapper {
     return false;
   }
 
-  private Long toMillis(final Long value, final TimeUnit precision) {
+  private Long toMillis(final long value, final TimeUnit precision) {
 
     return TimeUnit.MILLISECONDS.convert(value, precision);
   }


### PR DESCRIPTION
The `InfluxDBResultMapper` is not able map QueryResults with different precision than Milliseconds.

```java
@Test
void testToPOJO_Precision() {

	String database = "precision_database";
	influxDB.deleteDatabase(database);
	influxDB.createDatabase(database);

	// write in Nanoseconds
	influxDB.write(database, "autogen", InfluxDB.ConsistencyLevel.ONE,
				"h2o_feet,location=coyote_creek level\\ description=\"below 3 feet\",water_level=2.927 1000000000");

	// query in Seconds
	QueryResult queryResults = influxDB.query(new Query("select * from h2o_feet", database), TimeUnit.SECONDS);

	// Mapper expected time in Milliseconds
	List<H2OFeetMeasurement> measurements = new InfluxDBResultMapper().toPOJO(queryResults, H2OFeetMeasurement.class);

	Assertions.assertEquals(1, measurements.size());
	Assertions.assertEquals("coyote_creek", measurements.get(0).location);
	Assertions.assertEquals(2.927D, (double) measurements.get(0).level);
	Assertions.assertEquals("below 3 feet", measurements.get(0).description);
	Assertions.assertEquals(Instant.ofEpochSecond(1), measurements.get(0).time);
}

@Measurement(name = "h2o_feet", timeUnit = TimeUnit.NANOSECONDS)
public static class H2OFeetMeasurement {

	@Column(name = "location", tag = true)
	private String location;

	@Column(name = "water_level")
	private Double level;

	@Column(name = "level description")
	private String description;

	@Column(name = "time")
	private Instant time;
}
```