### PR TITLE
fix issues 498: Added streaming with time units to the influx db interface

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -440,6 +440,37 @@ public interface InfluxDB {
   public void query(Query query, int chunkSize, Consumer<QueryResult> consumer);
 
   /**
+   * Execute a streaming postQuery against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param consumer
+   *            the consumer to invoke for each received QueryResult
+   * @param timeUnit
+   *            the time unit of the results.
+   */
+  public void query(Query query, TimeUnit timeUnit, int chunkSize, Consumer<QueryResult> consumer);
+
+  /**
+   * Execute a streaming postQuery against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param timeUnit
+   *            the time unit of the results.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onSuccess
+   *            the consumer to invoke when result is received
+   * @param onFailure
+   *            the consumer to invoke when error is thrown
+   */
+  public void query(Query query, TimeUnit timeUnit, int chunkSize,
+          Consumer<QueryResult> onSuccess, Consumer<Throwable> onFailure);
+
+  /**
    * Execute a query against a database.
    *
    * @param query

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -524,42 +524,81 @@ public class InfluxDBImpl implements InfluxDB {
    * {@inheritDoc}
    */
   @Override
-    public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
-        Call<ResponseBody> call = null;
-        if (query instanceof BoundParameterQuery) {
-            BoundParameterQuery boundParameterQuery = (BoundParameterQuery) query;
-            call = this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize,
-                    boundParameterQuery.getParameterJsonWithUrlEncoded());
-        } else {
-            call = this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
-        }
+  public void query(final Query query, final int chunkSize, final Consumer<QueryResult> consumer) {
+    query(query, null, chunkSize, consumer, null);
+  }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void query(final Query query, final TimeUnit timeUnit,
+      final int chunkSize, final Consumer<QueryResult> consumer) {
+    query(query, timeUnit, chunkSize, consumer, null);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void query(final Query query, final TimeUnit timeUnit, final int chunkSize,
+      final Consumer<QueryResult> onSuccess, final Consumer<Throwable> onFailure) {
+    Call<ResponseBody> call = makeResponseBodyCall(query, timeUnit, chunkSize);
     call.enqueue(new Callback<ResponseBody>() {
       @Override
       public void onResponse(final Call<ResponseBody> call, final Response<ResponseBody> response) {
         try {
           if (response.isSuccessful()) {
             ResponseBody chunkedBody = response.body();
-            chunkProccesor.process(chunkedBody, consumer);
+            chunkProccesor.process(chunkedBody, onSuccess);
           } else {
             // REVIEW: must be handled consistently with IOException.
             ResponseBody errorBody = response.errorBody();
             if (errorBody != null) {
-              throw new InfluxDBException(errorBody.string());
+              InfluxDBException errorBodyException = new InfluxDBException(errorBody.string());
+              if (onFailure != null) {
+                onFailure.accept(errorBodyException);
+              } else {
+                throw errorBodyException;
+              }
             }
           }
         } catch (IOException e) {
           QueryResult queryResult = new QueryResult();
           queryResult.setError(e.toString());
-          consumer.accept(queryResult);
+          onSuccess.accept(queryResult);
         }
       }
 
-            @Override
-            public void onFailure(final Call<ResponseBody> call, final Throwable t) {
-                throw new InfluxDBException(t);
-            }
-        });
+      @Override
+      public void onFailure(final Call<ResponseBody> call, final Throwable t) {
+        if (onFailure != null) {
+          onFailure.accept(t);
+        } else {
+          throw new InfluxDBException(t);
+        }
+      }
+    });
+  }
+
+  private Call<ResponseBody> makeResponseBodyCall(final Query query, final TimeUnit timeUnit, final int chunkSize) {
+    if (query instanceof BoundParameterQuery) {
+      BoundParameterQuery boundParameterQuery = (BoundParameterQuery) query;
+      if (timeUnit == null) {
+        return this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize,
+                                          boundParameterQuery.getParameterJsonWithUrlEncoded());
+      }
+      return this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(),
+                                        TimeUtil.toTimePrecision(timeUnit),
+                                        chunkSize, boundParameterQuery.getParameterJsonWithUrlEncoded());
+    } else {
+      if (timeUnit == null) {
+        return this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(), chunkSize);
+      }
+
+      return this.influxDBService.query(query.getDatabase(), query.getCommandWithUrlEncoded(),
+                                               TimeUtil.toTimePrecision(timeUnit), chunkSize);
+    }
   }
 
   /**

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -76,7 +76,18 @@ interface InfluxDBService {
       @Query(CHUNK_SIZE) int chunkSize);
 
   @Streaming
+  @GET("query?chunked=true")
+  public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query,
+          @Query(EPOCH) String epoch, @Query(CHUNK_SIZE) int chunkSize);
+
+  @Streaming
   @POST("query?chunked=true")
   public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query,
           @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
+
+  @Streaming
+  @POST("query?chunked=true")
+  public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query,
+          @Query(EPOCH) String precision, @Query(CHUNK_SIZE) int chunkSize,
+          @Query(value = PARAMS, encoded = true) String params);
 }


### PR DESCRIPTION
Fix for issues #498 to propagate exception if you are using the query stream.

Adds also functionality to specify the time unit to the query stream. This feature was also disred by #418.
It is needed if you want to stream a great among of data and don't want to parse the dates from the ISO format to an epoch timestamp.