### PR TITLE
fix issue #517 : missing millis and nanos in MsgPack

### DIFF
--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -91,9 +92,17 @@ public class MessagePackInfluxDBTest extends InfluxDBTest {
 
     // THEN the measure points have a timestamp with second precision
     QueryResult queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName));
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0), t1);
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0), t2);
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0), t3);
+    long bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0));
+    Assertions.assertEquals(bySecond, t1);
+    
+    bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0));
+    Assertions.assertEquals(bySecond, t2);
+    
+    bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0));
+    Assertions.assertEquals(bySecond, t3);
 
     this.influxDB.deleteDatabase(dbName);
   }
@@ -182,9 +191,19 @@ public class MessagePackInfluxDBTest extends InfluxDBTest {
     // THEN the measure points have a timestamp with second precision
     QueryResult queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName));
     Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().size(), 3);
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0), timeP1);
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0), timeP2);
-    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0), timeP3);
+    
+    long bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0));
+    Assertions.assertEquals(bySecond, timeP1);
+
+    bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0));
+    Assertions.assertEquals(bySecond, timeP2);
+    
+    bySecond = TimeUnit.NANOSECONDS.toSeconds(
+        (Long) queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0));
+    Assertions.assertEquals(bySecond, timeP3);
+
     this.influxDB.deleteDatabase(dbName);
   }
 

--- a/src/test/java/org/influxdb/msgpack/MessagePackTraverserTest.java
+++ b/src/test/java/org/influxdb/msgpack/MessagePackTraverserTest.java
@@ -33,7 +33,8 @@ public class MessagePackTraverserTest {
     QueryResult result = iter.next();
     List<List<Object>> values = result.getResults().get(0).getSeries().get(0).getValues();
     Assertions.assertEquals(2, values.size());
-    assertEquals(1532325083L, values.get(0).get(0));
+    
+    assertEquals(1532325083803052600L, values.get(0).get(0));
     assertEquals("b", values.get(1).get(1));
     
     assertTrue(iter.hasNext());
@@ -56,7 +57,7 @@ public class MessagePackTraverserTest {
     QueryResult queryResult = traverser.parse(MessagePackTraverserTest.class.getResourceAsStream("msgpack_2.bin"));
     List<List<Object>> values = queryResult.getResults().get(0).getSeries().get(0).getValues();
     Assertions.assertEquals(3, values.size());
-    assertEquals(1485273600L, values.get(0).get(0));
+    assertEquals(1485273600000000000L, values.get(0).get(0));
     assertEquals("two", values.get(1).get(1));
     assertEquals(3.0, values.get(2).get(2));
   }


### PR DESCRIPTION
decode time exhaustedly to Epoch nanos so we make sure nothing lost

according to https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_reference/
epoch nano timestamp in influxdb fits into a Long, so we can be sure no Long overflow.