### PR TITLE
Fixed issue #523: onError handling for chunked queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.14
+
+- Fixed chunked query exception handling [Issue #523](https://github.com/influxdata/influxdb-java/issues/523)
+
+
 ## 2.13 [2018-09-12]
 
 ### Fixes

--- a/FAQ.md
+++ b/FAQ.md
@@ -12,6 +12,7 @@
     - [How the client responds to concurrent write backpressure from server ?](#how-the-client-responds-to-concurrent-write-backpressure-from-server)
     - [Is there a way to tell that all query chunks have arrived ?](#is-there-a-way-to-tell-that-all-query-chunks-have-arrived)
     - [Is there a way to tell the system to stop sending more chunks once I've found what I'm looking for ?](#is-there-a-way-to-tell-the-system-to-stop-sending-more-chunks-once-ive-found-what-im-looking-for)
+    - [How to handle exceptions while using async chunked queries ?](#how-to-handle-exceptions-while-using-async-chunked-queries)
     - [Is default config security setup TLS 1.2 ?](#is-default-config-security-setup-tls-12)
     - [How to use SSL client certificate authentication](#how-to-use-ssl-client-certificate-authentication)
 
@@ -82,6 +83,28 @@ influxDB.query(new Query("SELECT * FROM disk", "telegraf"), 10_000,
     () -> {
         System.out.println("The query successfully finished.");
     });
+```
+## How to handle exceptions while using async chunked queries ?
+
+Exception handling for chunked queries can be handled by __onFailure__ error 
+consumer. 
+   
+```java
+
+influxDB.query(query, chunksize,
+        //onNext result consumer
+        (cancellable, queryResult) -> {
+            System.out.println("Process queryResult - " + queryResult.toString());
+        }
+        //onComplete executable
+        , () -> {
+            System.out.println("On Complete - the query finished successfully.");
+        },
+        //onFailure error handler
+        throwable -> {
+            System.out.println("On Failure - " + throwable.getLocalizedMessage());
+        });
+    
 ```
 
 ## Is there a way to tell the system to stop sending more chunks once I've found what I'm looking for ?

--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -520,6 +520,23 @@ public interface InfluxDB {
   public void query(Query query, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext, Runnable onComplete);
 
   /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onNext
+   *            the consumer to invoke for each received QueryResult; with capability to discontinue a streaming query
+   * @param onComplete
+   *            the onComplete to invoke for successfully end of stream
+   * @param onFailure
+   *            the consumer for error handling
+   */
+  public void query(Query query, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext, Runnable onComplete,
+                    Consumer<Throwable> onFailure);
+
+  /**
    * Execute a query against a database.
    *
    * @param query

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -643,13 +643,12 @@ public class InfluxDBImpl implements InfluxDB {
             }
           }
         } catch (IOException e) {
+          QueryResult queryResult = new QueryResult();
+          queryResult.setError(e.toString());
+          onNext.accept(cancellable, queryResult);
           //passing null onFailure consumer is here for backward compatibility
           //where the empty queryResult containing error is propagating into onNext consumer
-          if (onFailure == null) {
-            QueryResult queryResult = new QueryResult();
-            queryResult.setError(e.toString());
-            onNext.accept(cancellable, queryResult);
-          } else {
+          if (onFailure != null) {
             onFailure.accept(e);
           }
         }


### PR DESCRIPTION
Added missing onFailure consumer for async chunking streaming query API. 