### PR TITLE
Add save and load functionalities using measurement models

### DIFF
--- a/INFLUXDB_MAPPER.md
+++ b/INFLUXDB_MAPPER.md
@@ -1,6 +1,6 @@
 ### InfluxDBMapper
 
-In case you want to use models only you can use the InfluxDBMapper to save and load measurements.
+In case you want to use models only, you can use the InfluxDBMapper to save and load measurements.
 You can create models that specify the database the measurement and the retention policy.
 
 ```Java
@@ -25,7 +25,7 @@ public class Cpu {
 Save operation using a model.
 
 ```Java
-Cpu cpu = ..create the cpu measure
+Cpu cpu = .., create the cpu measure
 influxDBMapper.save(cpu);
 ```
 
@@ -35,10 +35,10 @@ Load data using a model.
 Cpu persistedCpu = influxDBMapper.query(Cpu.class).get(0);
 ```
 
-Load data using a query and specify the model fro mapping.
+Load data using a query and specify the model for mapping.
 
 ```java
-Query query = ..create your query
+Query query = ... create your query
 List<Cpu> persistedMeasure = influxDBMapper.query(query,Cpu.class);
 ```
 

--- a/INFLUXDB_MAPPER.md
+++ b/INFLUXDB_MAPPER.md
@@ -1,0 +1,50 @@
+### InfluxDBMapper
+
+In case you want to use models only you can use the InfluxDBMapper to save and load measurements.
+You can create models that specify the database the measurement and the retention policy.
+
+```Java
+@Measurement(name = "cpu",database="servers", retentionPolicy="autogen",timeUnit = TimeUnit.MILLISECONDS)
+public class Cpu {
+    @Column(name = "time")
+    private Instant time;
+    @Column(name = "host", tag = true)
+    private String hostname;
+    @Column(name = "region", tag = true)
+    private String region;
+    @Column(name = "idle")
+    private Double idle;
+    @Column(name = "happydevop")
+    private Boolean happydevop;
+    @Column(name = "uptimesecs")
+    private Long uptimeSecs;
+    // getters (and setters if you need)
+}
+```
+
+Save operation using a model.
+
+```Java
+Cpu cpu = ..create the cpu measure
+influxDBMapper.save(cpu);
+```
+
+Load data using a model.
+
+```java
+Cpu persistedCpu = influxDBMapper.query(Cpu.class).get(0);
+```
+
+Load data using a query and specify the model fro mapping.
+
+```java
+Query query = ..create your query
+List<Cpu> persistedMeasure = influxDBMapper.query(query,Cpu.class);
+```
+
+#### InfluxDBMapper limitations
+
+Tags are automatically converted to strings, since tags are strings to influxdb
+Supported values for fields are boolean, int, long, double, Boolean, Integer, Long, Double.
+The time field should be of type instant. 
+If you do not specify the time or set a value then the current system time shall be used with the timeunit specified.

--- a/README.md
+++ b/README.md
@@ -273,41 +273,7 @@ List<Cpu> cpuList = resultMapper.toPOJO(queryResult, Cpu.class);
 
 ### InfluxDBMapper
 
-In case you want to use models only you can use the InfluxDBMapper to save and load measurements.
-You can create models that specify the database the measurement and the retention policy.
-
-```Java
-@Measurement(name = "cpu",database="servers", retentionPolicy="autogen",timeUnit = TimeUnit.MILLISECONDS)
-public class Cpu {
-    @Column(name = "time")
-    private Instant time;
-    @Column(name = "host", tag = true)
-    private String hostname;
-    @Column(name = "region", tag = true)
-    private String region;
-    @Column(name = "idle")
-    private Double idle;
-    @Column(name = "happydevop")
-    private Boolean happydevop;
-    @Column(name = "uptimesecs")
-    private Long uptimeSecs;
-    // getters (and setters if you need)
-}
-```
-
-The save them and load them by using the model.
-
-```Java
-influxDBMapper.save(cpu);
-Cpu persistedCpu = influxDBMapper.query(Cpu.class).get(0);
-```
-
-#### InfluxDBMapper limitations
-
-Tags are automatically converted to strings, since tags are strings to influxdb
-Supported values for fields are boolean, int, long, double, Boolean, Integer, Long, Double.
-The time field should be of type instant. 
-If you do not specify the time or set a value then the current system time shall be used with the timeunit specified.
+In case you want to save and load data using models you can use the [InfluxDBMapper](INFLUXDB_MAPPER.md).
 
 #### Query using Callbacks (version 2.8+ required)
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,44 @@ List<Cpu> cpuList = resultMapper.toPOJO(queryResult, Cpu.class);
 
 -- _Note: With the current released version (2.7), InfluxDBResultMapper does not support QueryResult created by queries using the "GROUP BY" clause. This was fixed by [PR #345](https://github.com/influxdata/influxdb-java/pull/345)._
 
+### InfluxDBMapper
+
+In case you want to use models only you can use the InfluxDBMapper to save and load measurements.
+You can create models that specify the database the measurement and the retention policy.
+
+```Java
+@Measurement(name = "cpu",database="servers", retentionPolicy="autogen",timeUnit = TimeUnit.MILLISECONDS)
+public class Cpu {
+    @Column(name = "time")
+    private Instant time;
+    @Column(name = "host", tag = true)
+    private String hostname;
+    @Column(name = "region", tag = true)
+    private String region;
+    @Column(name = "idle")
+    private Double idle;
+    @Column(name = "happydevop")
+    private Boolean happydevop;
+    @Column(name = "uptimesecs")
+    private Long uptimeSecs;
+    // getters (and setters if you need)
+}
+```
+
+The save them and load them by using the model.
+
+```Java
+influxDBMapper.save(cpu);
+Cpu persistedCpu = influxDBMapper.query(Cpu.class).get(0);
+```
+
+#### InfluxDBMapper limitations
+
+Tags are automatically converted to strings, since tags are strings to influxdb
+Supported values for fields are boolean, int, long, double, Boolean, Integer, Long, Double.
+The time field should be of type instant. 
+If you do not specify the time or set a value then the current system time shall be used with the timeunit specified.
+
 #### Query using Callbacks (version 2.8+ required)
 
 influxdb-java now supports returning results of a query via callbacks. Only one

--- a/src/main/java/org/influxdb/annotation/Measurement.java
+++ b/src/main/java/org/influxdb/annotation/Measurement.java
@@ -35,5 +35,7 @@ public @interface Measurement {
 
   String name();
 
+  String database() default "[unassigned]";
+
   TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
 }

--- a/src/main/java/org/influxdb/annotation/Measurement.java
+++ b/src/main/java/org/influxdb/annotation/Measurement.java
@@ -37,5 +37,7 @@ public @interface Measurement {
 
   String database() default "[unassigned]";
 
+  String retentionPolicy() default "autogen";
+
   TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -1,0 +1,100 @@
+package org.influxdb.impl;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBMapperException;
+import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Measurement;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+public class InfluxDBMapper extends InfluxDBResultMapper {
+
+    private final InfluxDB influxDB;
+
+    public InfluxDBMapper(InfluxDB influxDB) {
+        this.influxDB = influxDB;
+    }
+
+    public <T> List<T> query(final Query query,final Class<T> clazz) {
+        throwExceptionIfMissingAnnotation(clazz);
+        QueryResult queryResult = influxDB.query(query);
+        return toPOJO(queryResult, clazz);
+    }
+
+    public <T> List<T> query(final Class<T> clazz) {
+        throwExceptionIfMissingAnnotation(clazz);
+
+        String measurement = getMeasurementName(clazz);
+        String database = getDatabaseName(clazz);
+
+        if (database.equals("[unassigned]")) {
+            throw new IllegalArgumentException(
+                    Measurement.class.getSimpleName()+" of class "+clazz.getName()+" should specify a database value for this operation");
+        }
+
+        QueryResult queryResult = influxDB.query(new Query("SELECT * FROM "+measurement, database));
+        return toPOJO(queryResult, clazz);
+    }
+
+    public <T> void save(T model) {
+       throwExceptionIfMissingAnnotation(model.getClass());
+       cacheMeasurementClass(model.getClass());
+
+       ConcurrentMap<String, Field> colNameAndFieldMap = getColNameAndFieldMap(model.getClass());
+
+       try {
+
+           String measurement = getMeasurementName(model.getClass());
+           String database = getDatabaseName(model.getClass());
+           TimeUnit timeUnit = getTimeUnit(model.getClass());
+           long time = timeUnit.convert(System.nanoTime(),TimeUnit.NANOSECONDS);
+           Point.Builder pointBuilder = Point.measurement(measurement).time(
+                   time,timeUnit);
+
+        for (String key : colNameAndFieldMap.keySet()) {
+
+            Field field = colNameAndFieldMap.get(key);
+            Column column = field.getAnnotation(Column.class);
+
+            String columnName = column.name();
+            Object value = field.get(model).toString();
+
+            if(column.tag()) {
+                /**
+                 * Tags are strings either way
+                 */
+                pointBuilder.tag(columnName,value.toString());
+            } else {
+
+                /**
+                 * Check the primitives, and check what happens on double vs Double
+                 */
+                if(field.getType().equals(Boolean.TYPE)) {
+                    pointBuilder.addField(columnName, (boolean) value);
+                } else if (field.getType().equals(Long.TYPE)) {
+                    pointBuilder.addField(columnName,(long) value);
+                } else if(field.getType().equals(Double.TYPE)) {
+                    pointBuilder.addField(columnName, (double) value);
+                } else if(field.getType().equals(Number.class)) {
+                    pointBuilder.addField(columnName, (Number) value);
+                } else if(field.getType().equals(String.class)) {
+                    pointBuilder.addField(columnName, (String) value);
+                } else {
+                    throw new IllegalArgumentException("Argument does not apply");
+                }
+            }
+
+            influxDB.write(pointBuilder.build());
+        }
+       } catch (IllegalAccessException e) {
+           throw new InfluxDBMapperException(e);
+       }
+    }
+
+}

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -16,6 +16,7 @@ import org.influxdb.dto.QueryResult;
 public class InfluxDBMapper extends InfluxDBResultMapper {
 
   private final InfluxDB influxDB;
+  private final long nanoConstant = 1000000000L;
 
   public InfluxDBMapper(final InfluxDB influxDB) {
     this.influxDB = influxDB;
@@ -134,10 +135,15 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     }
   }
 
-  private long instantToNano(Instant instant) {
-    Instant inst = Instant.now();
+  /**
+   * Converts instant to nanoseconds.
+   * @param instant
+   * @return
+   */
+  private long instantToNano(final Instant instant) {
+    Instant inst = instant.now();
     long time = inst.getEpochSecond();
-    time *= 1000000000l; // convert to nanoseconds
+    time *= nanoConstant;
     time += inst.getNano();
     return time;
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -16,7 +16,6 @@ import org.influxdb.dto.QueryResult;
 public class InfluxDBMapper extends InfluxDBResultMapper {
 
   private final InfluxDB influxDB;
-  private final long nanoConstant = 1000000000L;
 
   public InfluxDBMapper(final InfluxDB influxDB) {
     this.influxDB = influxDB;
@@ -105,7 +104,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
       final Object value) {
     if (Instant.class.isAssignableFrom(fieldType)) {
       Instant instant = (Instant) value;
-      long time = timeUnit.convert(instantToNano(instant), TimeUnit.MILLISECONDS);
+      long time = timeUnit.convert(instant.toEpochMilli(), TimeUnit.MILLISECONDS);
       pointBuilder.time(time, timeUnit);
     } else {
       throw new InfluxDBMapperException(
@@ -135,16 +134,4 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     }
   }
 
-  /**
-   * Converts instant to nanoseconds.
-   * @param instant
-   * @return
-   */
-  private long instantToNano(final Instant instant) {
-    Instant inst = instant.now();
-    long time = inst.getEpochSecond();
-    time *= nanoConstant;
-    time += inst.getNano();
-    return time;
-  }
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -16,7 +16,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
 
   private final InfluxDB influxDB;
 
-  public InfluxDBMapper(InfluxDB influxDB) {
+  public InfluxDBMapper(final InfluxDB influxDB) {
     this.influxDB = influxDB;
   }
 
@@ -32,7 +32,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     String measurement = getMeasurementName(clazz);
     String database = getDatabaseName(clazz);
 
-    if (database.equals("[unassigned]")) {
+    if ("[unassigned]".equals(database)) {
       throw new IllegalArgumentException(
           Measurement.class.getSimpleName()
               + " of class "
@@ -44,7 +44,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     return toPOJO(queryResult, clazz);
   }
 
-  public <T> void save(T model) {
+  public <T> void save(final T model) {
     throwExceptionIfMissingAnnotation(model.getClass());
     cacheMeasurementClass(model.getClass());
 

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -41,7 +41,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
               + " should specify a database value for this operation");
     }
 
-    QueryResult queryResult = influxDB.query(new Query("SELECT * FROM " + measurement,database));
+    QueryResult queryResult = influxDB.query(new Query("SELECT * FROM " + measurement, database));
     return toPOJO(queryResult, clazz);
   }
 

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -1,5 +1,9 @@
 package org.influxdb.impl;
 
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBMapperException;
 import org.influxdb.annotation.Column;
@@ -8,93 +12,85 @@ import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-
 public class InfluxDBMapper extends InfluxDBResultMapper {
 
-    private final InfluxDB influxDB;
+  private final InfluxDB influxDB;
 
-    public InfluxDBMapper(InfluxDB influxDB) {
-        this.influxDB = influxDB;
+  public InfluxDBMapper(InfluxDB influxDB) {
+    this.influxDB = influxDB;
+  }
+
+  public <T> List<T> query(final Query query, final Class<T> clazz) {
+    throwExceptionIfMissingAnnotation(clazz);
+    QueryResult queryResult = influxDB.query(query);
+    return toPOJO(queryResult, clazz);
+  }
+
+  public <T> List<T> query(final Class<T> clazz) {
+    throwExceptionIfMissingAnnotation(clazz);
+
+    String measurement = getMeasurementName(clazz);
+    String database = getDatabaseName(clazz);
+
+    if (database.equals("[unassigned]")) {
+      throw new IllegalArgumentException(
+          Measurement.class.getSimpleName()
+              + " of class "
+              + clazz.getName()
+              + " should specify a database value for this operation");
     }
 
-    public <T> List<T> query(final Query query,final Class<T> clazz) {
-        throwExceptionIfMissingAnnotation(clazz);
-        QueryResult queryResult = influxDB.query(query);
-        return toPOJO(queryResult, clazz);
-    }
+    QueryResult queryResult = influxDB.query(new Query("SELECT * FROM " + measurement, database));
+    return toPOJO(queryResult, clazz);
+  }
 
-    public <T> List<T> query(final Class<T> clazz) {
-        throwExceptionIfMissingAnnotation(clazz);
+  public <T> void save(T model) {
+    throwExceptionIfMissingAnnotation(model.getClass());
+    cacheMeasurementClass(model.getClass());
 
-        String measurement = getMeasurementName(clazz);
-        String database = getDatabaseName(clazz);
+    ConcurrentMap<String, Field> colNameAndFieldMap = getColNameAndFieldMap(model.getClass());
 
-        if (database.equals("[unassigned]")) {
-            throw new IllegalArgumentException(
-                    Measurement.class.getSimpleName()+" of class "+clazz.getName()+" should specify a database value for this operation");
+    try {
+
+      String measurement = getMeasurementName(model.getClass());
+      String database = getDatabaseName(model.getClass());
+      TimeUnit timeUnit = getTimeUnit(model.getClass());
+      long time = timeUnit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+      Point.Builder pointBuilder = Point.measurement(measurement).time(time, timeUnit);
+
+      for (String key : colNameAndFieldMap.keySet()) {
+
+        Field field = colNameAndFieldMap.get(key);
+        Column column = field.getAnnotation(Column.class);
+
+        String columnName = column.name();
+        Object value = field.get(model).toString();
+
+        if (column.tag()) {
+          /** Tags are strings either way */
+          pointBuilder.tag(columnName, value.toString());
+        } else {
+
+          /** Check the primitives, and check what happens on double vs Double */
+          if (field.getType().equals(Boolean.TYPE)) {
+            pointBuilder.addField(columnName, (boolean) value);
+          } else if (field.getType().equals(Long.TYPE)) {
+            pointBuilder.addField(columnName, (long) value);
+          } else if (field.getType().equals(Double.TYPE)) {
+            pointBuilder.addField(columnName, (double) value);
+          } else if (field.getType().equals(Number.class)) {
+            pointBuilder.addField(columnName, (Number) value);
+          } else if (field.getType().equals(String.class)) {
+            pointBuilder.addField(columnName, (String) value);
+          } else {
+            throw new IllegalArgumentException("Argument does not apply");
+          }
         }
 
-        QueryResult queryResult = influxDB.query(new Query("SELECT * FROM "+measurement, database));
-        return toPOJO(queryResult, clazz);
+        influxDB.write(pointBuilder.build());
+      }
+    } catch (IllegalAccessException e) {
+      throw new InfluxDBMapperException(e);
     }
-
-    public <T> void save(T model) {
-       throwExceptionIfMissingAnnotation(model.getClass());
-       cacheMeasurementClass(model.getClass());
-
-       ConcurrentMap<String, Field> colNameAndFieldMap = getColNameAndFieldMap(model.getClass());
-
-       try {
-
-           String measurement = getMeasurementName(model.getClass());
-           String database = getDatabaseName(model.getClass());
-           TimeUnit timeUnit = getTimeUnit(model.getClass());
-           long time = timeUnit.convert(System.nanoTime(),TimeUnit.NANOSECONDS);
-           Point.Builder pointBuilder = Point.measurement(measurement).time(
-                   time,timeUnit);
-
-        for (String key : colNameAndFieldMap.keySet()) {
-
-            Field field = colNameAndFieldMap.get(key);
-            Column column = field.getAnnotation(Column.class);
-
-            String columnName = column.name();
-            Object value = field.get(model).toString();
-
-            if(column.tag()) {
-                /**
-                 * Tags are strings either way
-                 */
-                pointBuilder.tag(columnName,value.toString());
-            } else {
-
-                /**
-                 * Check the primitives, and check what happens on double vs Double
-                 */
-                if(field.getType().equals(Boolean.TYPE)) {
-                    pointBuilder.addField(columnName, (boolean) value);
-                } else if (field.getType().equals(Long.TYPE)) {
-                    pointBuilder.addField(columnName,(long) value);
-                } else if(field.getType().equals(Double.TYPE)) {
-                    pointBuilder.addField(columnName, (double) value);
-                } else if(field.getType().equals(Number.class)) {
-                    pointBuilder.addField(columnName, (Number) value);
-                } else if(field.getType().equals(String.class)) {
-                    pointBuilder.addField(columnName, (String) value);
-                } else {
-                    throw new IllegalArgumentException("Argument does not apply");
-                }
-            }
-
-            influxDB.write(pointBuilder.build());
-        }
-       } catch (IllegalAccessException e) {
-           throw new InfluxDBMapperException(e);
-       }
-    }
-
+  }
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -42,7 +42,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
               + " should specify a database value for this operation");
     }
 
-    QueryResult queryResult = influxDB.query(new Query("SELECT * FROM " + measurement, database));
+    QueryResult queryResult = influxDB.query(new Query("SELECT * FROM " + measurement,database));
     return toPOJO(queryResult, clazz);
   }
 
@@ -58,7 +58,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
       String database = getDatabaseName(modelType);
       String retentionPolicy = getRetentionPolicy(modelType);
       TimeUnit timeUnit = getTimeUnit(modelType);
-      long time = timeUnit.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
+      long time = timeUnit.convert(System.currentTimeMillis(), TimeUnit.MILLISECONDS);
       Point.Builder pointBuilder = Point.measurement(measurement).time(time, timeUnit);
 
       for (String key : colNameAndFieldMap.keySet()) {

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -73,12 +73,10 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
         Object value = field.get(model);
 
         if (column.tag()) {
-          /**
-           * Tags are strings either way.
-           */
+          /** Tags are strings either way. */
           pointBuilder.tag(columnName, value.toString());
         } else if ("time".equals(columnName)) {
-          if( value !=null) {
+          if (value != null) {
             setTime(pointBuilder, fieldType, timeUnit, value);
           }
         } else {
@@ -91,7 +89,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
       if ("[unassigned]".equals(database)) {
         influxDB.write(point);
       } else {
-        influxDB.write(database,retentionPolicy,point);
+        influxDB.write(database, retentionPolicy, point);
       }
 
     } catch (IllegalAccessException e) {
@@ -99,38 +97,48 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     }
   }
 
-  private void setTime(final Point.Builder pointBuilder,final Class<?> fieldType, final TimeUnit timeUnit,final Object value) {
+  private void setTime(
+      final Point.Builder pointBuilder,
+      final Class<?> fieldType,
+      final TimeUnit timeUnit,
+      final Object value) {
     if (Instant.class.isAssignableFrom(fieldType)) {
       Instant instant = (Instant) value;
       long time = timeUnit.convert(instantToNano(instant), TimeUnit.MILLISECONDS);
-      pointBuilder.time(time,timeUnit);
+      pointBuilder.time(time, timeUnit);
     } else {
-      throw new InfluxDBMapperException("Unsupported type " + fieldType + " for time: should be of Instant type");
+      throw new InfluxDBMapperException(
+          "Unsupported type " + fieldType + " for time: should be of Instant type");
     }
   }
 
-  private void setField(final Point.Builder pointBuilder, final Class<?> fieldType, final String columnName, final Object value) {
+  private void setField(
+      final Point.Builder pointBuilder,
+      final Class<?> fieldType,
+      final String columnName,
+      final Object value) {
     if (boolean.class.isAssignableFrom(fieldType) || Boolean.class.isAssignableFrom(fieldType)) {
       pointBuilder.addField(columnName, (boolean) value);
     } else if (long.class.isAssignableFrom(fieldType) || Long.class.isAssignableFrom(fieldType)) {
       pointBuilder.addField(columnName, (long) value);
-    } else if (double.class.isAssignableFrom(fieldType) || Double.class.isAssignableFrom(fieldType)) {
+    } else if (double.class.isAssignableFrom(fieldType)
+        || Double.class.isAssignableFrom(fieldType)) {
       pointBuilder.addField(columnName, (double) value);
     } else if (int.class.isAssignableFrom(fieldType) || Integer.class.isAssignableFrom(fieldType)) {
       pointBuilder.addField(columnName, (int) value);
     } else if (String.class.isAssignableFrom(fieldType)) {
       pointBuilder.addField(columnName, (String) value);
     } else {
-      throw new InfluxDBMapperException("Unsupported type " + fieldType + " for column " + columnName);
+      throw new InfluxDBMapperException(
+          "Unsupported type " + fieldType + " for column " + columnName);
     }
   }
 
   private long instantToNano(Instant instant) {
     Instant inst = Instant.now();
     long time = inst.getEpochSecond();
-    time *= 1000000000l; //convert to nanoseconds
+    time *= 1000000000l; // convert to nanoseconds
     time += inst.getNano();
     return time;
   }
-
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -33,11 +33,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBMapperException;
 import org.influxdb.annotation.Column;
 import org.influxdb.annotation.Measurement;
-import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 
 /**
@@ -204,7 +202,7 @@ public class InfluxDBResultMapper {
     });
   }
 
-  ConcurrentMap<String, Field> getColNameAndFieldMap(Class<?> clazz) {
+  ConcurrentMap<String, Field> getColNameAndFieldMap(final Class<?> clazz) {
     return CLASS_FIELD_CACHE.get(clazz.getName());
   }
 

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -33,9 +33,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBMapperException;
 import org.influxdb.annotation.Column;
 import org.influxdb.annotation.Measurement;
+import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 
 /**
@@ -202,6 +204,10 @@ public class InfluxDBResultMapper {
     });
   }
 
+  ConcurrentMap<String, Field> getColNameAndFieldMap(Class<?> clazz) {
+    return CLASS_FIELD_CACHE.get(clazz.getName());
+  }
+
   void cacheMeasurementClass(final Class<?>... classVarAgrs) {
     for (Class<?> clazz : classVarAgrs) {
       if (CLASS_FIELD_CACHE.containsKey(clazz.getName())) {
@@ -224,6 +230,14 @@ public class InfluxDBResultMapper {
 
   String getMeasurementName(final Class<?> clazz) {
     return ((Measurement) clazz.getAnnotation(Measurement.class)).name();
+  }
+
+  String getDatabaseName(final Class<?> clazz) {
+    return ((Measurement) clazz.getAnnotation(Measurement.class)).database();
+  }
+
+  TimeUnit getTimeUnit(final Class<?> clazz) {
+    return ((Measurement) clazz.getAnnotation(Measurement.class)).timeUnit();
   }
 
   <T> List<T> parseSeriesAs(final QueryResult.Series series, final Class<T> clazz, final List<T> result) {

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -234,6 +234,10 @@ public class InfluxDBResultMapper {
     return ((Measurement) clazz.getAnnotation(Measurement.class)).database();
   }
 
+  String getRetentionPolicy(final Class<?> clazz) {
+    return ((Measurement) clazz.getAnnotation(Measurement.class)).retentionPolicy();
+  }
+
   TimeUnit getTimeUnit(final Class<?> clazz) {
     return ((Measurement) clazz.getAnnotation(Measurement.class)).timeUnit();
   }

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -1,0 +1,127 @@
+package org.influxdb.impl;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.TestUtils;
+import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Measurement;
+import org.influxdb.dto.Query;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public class InfluxDBMapperTest {
+
+    private InfluxDB influxDB;
+    private InfluxDBMapper influxDBMapper;
+    final static String UDP_DATABASE = "udp";
+
+    @Before
+    public void setUp() throws Exception {
+        this.influxDB = TestUtils.connectToInfluxDB();
+        this.influxDBMapper = new InfluxDBMapper(influxDB);
+    }
+
+    @Test
+    public void testSave() {
+        ServerMeasure serverMeasure = new ServerMeasure();
+        serverMeasure.setName("maverick");
+        serverMeasure.setCpu(4.3d);
+        serverMeasure.setHealthy(true);
+        serverMeasure.setUptime(1234l);
+        serverMeasure.setMemoryUtilization(new BigDecimal("34.5"));
+
+        influxDBMapper.save(serverMeasure);
+
+        ServerMeasure persistedMeasure = influxDBMapper.query(ServerMeasure.class).get(0);
+        Assert.assertEquals(serverMeasure.getName(),persistedMeasure.getName());
+        Assert.assertEquals(serverMeasure.getCpu(),persistedMeasure.getCpu(),0);
+        Assert.assertEquals(serverMeasure.isHealthy(),persistedMeasure.isHealthy());
+        Assert.assertEquals(serverMeasure.getUptime(),persistedMeasure.getUptime());
+        Assert.assertEquals(serverMeasure.getMemoryUtilization(),persistedMeasure.getMemoryUtilization());
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        influxDB.query(new Query("DROP DATABASE udp",UDP_DATABASE));
+    }
+
+    @Measurement(name = "server_measure")
+    private static class ServerMeasure {
+
+        /**
+         * Check the instant convertions
+         */
+        @Column(name = "time")
+        private Instant time;
+
+        @Column(name = "name", tag = true)
+        private String name;
+
+        @Column(name = "cpu", tag = true)
+        private double cpu;
+
+        @Column(name = "healthy")
+        private boolean healthy;
+
+        @Column(name = "min")
+        private long uptime;
+
+        @Column(name = "memory_utilization")
+        private BigDecimal memoryUtilization;
+
+        public Instant getTime() {
+            return time;
+        }
+
+        public void setTime(Instant time) {
+            this.time = time;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public double getCpu() {
+            return cpu;
+        }
+
+        public void setCpu(double cpu) {
+            this.cpu = cpu;
+        }
+
+        public boolean isHealthy() {
+            return healthy;
+        }
+
+        public void setHealthy(boolean healthy) {
+            this.healthy = healthy;
+        }
+
+        public long getUptime() {
+            return uptime;
+        }
+
+        public void setUptime(long uptime) {
+            this.uptime = uptime;
+        }
+
+        public BigDecimal getMemoryUtilization() {
+            return memoryUtilization;
+        }
+
+        public void setMemoryUtilization(BigDecimal memoryUtilization) {
+            this.memoryUtilization = memoryUtilization;
+        }
+
+    }
+
+}

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -37,7 +37,6 @@ public class InfluxDBMapperTest {
     serverMeasure.setHealthy(true);
     serverMeasure.setUptime(1234l);
     serverMeasure.setMemoryUtilization(new Double(34.5));
-    serverMeasure.setBigDecimal(new BigDecimal("1.2"));
 
     influxDBMapper.save(serverMeasure);
 
@@ -81,9 +80,6 @@ public class InfluxDBMapperTest {
 
     @Column(name = "min")
     private long uptime;
-
-    @Column(name = "test_dec")
-    private BigDecimal bigDecimal;
 
     /**
      * TODO bigdecimal unsupported?
@@ -139,13 +135,6 @@ public class InfluxDBMapperTest {
       this.memoryUtilization = memoryUtilization;
     }
 
-    public BigDecimal getBigDecimal() {
-      return bigDecimal;
-    }
-
-    public void setBigDecimal(BigDecimal bigDecimal) {
-      this.bigDecimal = bigDecimal;
-    }
   }
 
   @Measurement(name = "invalid_measure", database = UDP_DATABASE)

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -1,5 +1,7 @@
 package org.influxdb.impl;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import org.influxdb.InfluxDB;
 import org.influxdb.TestUtils;
 import org.influxdb.annotation.Column;
@@ -10,118 +12,111 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.math.BigDecimal;
-import java.time.Instant;
-import java.util.List;
-
 public class InfluxDBMapperTest {
 
-    private InfluxDB influxDB;
-    private InfluxDBMapper influxDBMapper;
-    final static String UDP_DATABASE = "udp";
+  private InfluxDB influxDB;
+  private InfluxDBMapper influxDBMapper;
+  static final String UDP_DATABASE = "udp";
 
-    @Before
-    public void setUp() throws Exception {
-        this.influxDB = TestUtils.connectToInfluxDB();
-        this.influxDBMapper = new InfluxDBMapper(influxDB);
+  @Before
+  public void setUp() throws Exception {
+    this.influxDB = TestUtils.connectToInfluxDB();
+    this.influxDBMapper = new InfluxDBMapper(influxDB);
+  }
+
+  @Test
+  public void testSave() {
+    ServerMeasure serverMeasure = new ServerMeasure();
+    serverMeasure.setName("maverick");
+    serverMeasure.setCpu(4.3d);
+    serverMeasure.setHealthy(true);
+    serverMeasure.setUptime(1234l);
+    serverMeasure.setMemoryUtilization(new BigDecimal("34.5"));
+
+    influxDBMapper.save(serverMeasure);
+
+    ServerMeasure persistedMeasure = influxDBMapper.query(ServerMeasure.class).get(0);
+    Assert.assertEquals(serverMeasure.getName(), persistedMeasure.getName());
+    Assert.assertEquals(serverMeasure.getCpu(), persistedMeasure.getCpu(), 0);
+    Assert.assertEquals(serverMeasure.isHealthy(), persistedMeasure.isHealthy());
+    Assert.assertEquals(serverMeasure.getUptime(), persistedMeasure.getUptime());
+    Assert.assertEquals(
+        serverMeasure.getMemoryUtilization(), persistedMeasure.getMemoryUtilization());
+  }
+
+  @After
+  public void cleanUp() throws Exception {
+    influxDB.query(new Query("DROP DATABASE udp", UDP_DATABASE));
+  }
+
+  @Measurement(name = "server_measure")
+  private static class ServerMeasure {
+
+    /** Check the instant convertions */
+    @Column(name = "time")
+    private Instant time;
+
+    @Column(name = "name", tag = true)
+    private String name;
+
+    @Column(name = "cpu", tag = true)
+    private double cpu;
+
+    @Column(name = "healthy")
+    private boolean healthy;
+
+    @Column(name = "min")
+    private long uptime;
+
+    @Column(name = "memory_utilization")
+    private BigDecimal memoryUtilization;
+
+    public Instant getTime() {
+      return time;
     }
 
-    @Test
-    public void testSave() {
-        ServerMeasure serverMeasure = new ServerMeasure();
-        serverMeasure.setName("maverick");
-        serverMeasure.setCpu(4.3d);
-        serverMeasure.setHealthy(true);
-        serverMeasure.setUptime(1234l);
-        serverMeasure.setMemoryUtilization(new BigDecimal("34.5"));
-
-        influxDBMapper.save(serverMeasure);
-
-        ServerMeasure persistedMeasure = influxDBMapper.query(ServerMeasure.class).get(0);
-        Assert.assertEquals(serverMeasure.getName(),persistedMeasure.getName());
-        Assert.assertEquals(serverMeasure.getCpu(),persistedMeasure.getCpu(),0);
-        Assert.assertEquals(serverMeasure.isHealthy(),persistedMeasure.isHealthy());
-        Assert.assertEquals(serverMeasure.getUptime(),persistedMeasure.getUptime());
-        Assert.assertEquals(serverMeasure.getMemoryUtilization(),persistedMeasure.getMemoryUtilization());
+    public void setTime(Instant time) {
+      this.time = time;
     }
 
-    @After
-    public void cleanUp() throws Exception {
-        influxDB.query(new Query("DROP DATABASE udp",UDP_DATABASE));
+    public String getName() {
+      return name;
     }
 
-    @Measurement(name = "server_measure")
-    private static class ServerMeasure {
-
-        /**
-         * Check the instant convertions
-         */
-        @Column(name = "time")
-        private Instant time;
-
-        @Column(name = "name", tag = true)
-        private String name;
-
-        @Column(name = "cpu", tag = true)
-        private double cpu;
-
-        @Column(name = "healthy")
-        private boolean healthy;
-
-        @Column(name = "min")
-        private long uptime;
-
-        @Column(name = "memory_utilization")
-        private BigDecimal memoryUtilization;
-
-        public Instant getTime() {
-            return time;
-        }
-
-        public void setTime(Instant time) {
-            this.time = time;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public double getCpu() {
-            return cpu;
-        }
-
-        public void setCpu(double cpu) {
-            this.cpu = cpu;
-        }
-
-        public boolean isHealthy() {
-            return healthy;
-        }
-
-        public void setHealthy(boolean healthy) {
-            this.healthy = healthy;
-        }
-
-        public long getUptime() {
-            return uptime;
-        }
-
-        public void setUptime(long uptime) {
-            this.uptime = uptime;
-        }
-
-        public BigDecimal getMemoryUtilization() {
-            return memoryUtilization;
-        }
-
-        public void setMemoryUtilization(BigDecimal memoryUtilization) {
-            this.memoryUtilization = memoryUtilization;
-        }
-
+    public void setName(String name) {
+      this.name = name;
     }
 
+    public double getCpu() {
+      return cpu;
+    }
+
+    public void setCpu(double cpu) {
+      this.cpu = cpu;
+    }
+
+    public boolean isHealthy() {
+      return healthy;
+    }
+
+    public void setHealthy(boolean healthy) {
+      this.healthy = healthy;
+    }
+
+    public long getUptime() {
+      return uptime;
+    }
+
+    public void setUptime(long uptime) {
+      this.uptime = uptime;
+    }
+
+    public BigDecimal getMemoryUtilization() {
+      return memoryUtilization;
+    }
+
+    public void setMemoryUtilization(BigDecimal memoryUtilization) {
+      this.memoryUtilization = memoryUtilization;
+    }
+  }
 }

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -42,6 +42,7 @@ public class InfluxDBMapperTest {
     Assert.assertEquals(serverMeasure.getCpu(), persistedMeasure.getCpu(), 0);
     Assert.assertEquals(serverMeasure.isHealthy(), persistedMeasure.isHealthy());
     Assert.assertEquals(serverMeasure.getUptime(), persistedMeasure.getUptime());
+    Assert.assertEquals(serverMeasure.getIp(),persistedMeasure.getIp());
     Assert.assertEquals(
         serverMeasure.getMemoryUtilization(), persistedMeasure.getMemoryUtilization());
   }
@@ -76,6 +77,16 @@ public class InfluxDBMapperTest {
     );
   }
 
+  @Test
+  public void testNonInstantTime() {
+    NonInstantTime nonInstantTime = new NonInstantTime();
+    nonInstantTime.setTime(1234566l);
+    assertThrows(
+        InfluxDBMapperException.class,
+        () -> influxDBMapper.save(nonInstantTime),
+        "time should be of type Instant"
+    );
+  }
 
   @Test
   public void testInstantOnTime() {
@@ -112,9 +123,11 @@ public class InfluxDBMapperTest {
     @Column(name = "min")
     private long uptime;
 
-    /** TODO bigdecimal unsupported? */
     @Column(name = "memory_utilization")
     private Double memoryUtilization;
+
+    @Column(name = "ip")
+    private String ip;
 
     public Instant getTime() {
       return time;
@@ -163,6 +176,14 @@ public class InfluxDBMapperTest {
     public void setMemoryUtilization(Double memoryUtilization) {
       this.memoryUtilization = memoryUtilization;
     }
+
+    public String getIp() {
+      return ip;
+    }
+
+    public void setIp(String ip) {
+      this.ip = ip;
+    }
   }
 
   @Measurement(name = "invalid_measure", database = UDP_DATABASE)
@@ -196,6 +217,21 @@ public class InfluxDBMapperTest {
     }
   }
 
+  @Measurement(name = "non_instant_time")
+  static class NonInstantTime {
+
+    @Column(name = "time")
+    private long time;
+
+    public long getTime() {
+      return time;
+    }
+
+    public void setTime(long time) {
+      this.time = time;
+    }
+  }
+
   private ServerMeasure createMeasure() {
     ServerMeasure serverMeasure = new ServerMeasure();
     serverMeasure.setName("maverick");
@@ -203,6 +239,7 @@ public class InfluxDBMapperTest {
     serverMeasure.setHealthy(true);
     serverMeasure.setUptime(1234l);
     serverMeasure.setMemoryUtilization(new Double(34.5));
+    serverMeasure.setIp("19.087.4.5");
     return serverMeasure;
   }
 

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -1,5 +1,7 @@
 package org.influxdb.impl;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 import org.influxdb.InfluxDB;
@@ -13,8 +15,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 public class InfluxDBMapperTest {
 
   private InfluxDB influxDB;
@@ -24,7 +24,7 @@ public class InfluxDBMapperTest {
   @BeforeEach
   public void setUp() throws Exception {
     this.influxDB = TestUtils.connectToInfluxDB();
-    this.influxDB.query(new Query("CREATE DATABASE "+UDP_DATABASE,UDP_DATABASE));
+    this.influxDB.query(new Query("CREATE DATABASE " + UDP_DATABASE, UDP_DATABASE));
     this.influxDB.setDatabase(UDP_DATABASE);
     this.influxDBMapper = new InfluxDBMapper(influxDB);
   }
@@ -54,7 +54,9 @@ public class InfluxDBMapperTest {
     InvalidMeasure invalidMeasure = new InvalidMeasure();
     invalidMeasure.setVal(new BigDecimal("2.3"));
     assertThrows(
-            InfluxDBMapperException.class, () -> influxDBMapper.save(invalidMeasure),"Non supported field");
+        InfluxDBMapperException.class,
+        () -> influxDBMapper.save(invalidMeasure),
+        "Non supported field");
   }
 
   @AfterEach
@@ -81,9 +83,7 @@ public class InfluxDBMapperTest {
     @Column(name = "min")
     private long uptime;
 
-    /**
-     * TODO bigdecimal unsupported?
-     */
+    /** TODO bigdecimal unsupported? */
     @Column(name = "memory_utilization")
     private Double memoryUtilization;
 
@@ -134,15 +134,12 @@ public class InfluxDBMapperTest {
     public void setMemoryUtilization(Double memoryUtilization) {
       this.memoryUtilization = memoryUtilization;
     }
-
   }
 
   @Measurement(name = "invalid_measure", database = UDP_DATABASE)
   static class InvalidMeasure {
 
-    /**
-     * Check the instant convertions
-     */
+    /** Check the instant convertions */
     @Column(name = "illegal_val")
     private BigDecimal val;
 
@@ -154,5 +151,4 @@ public class InfluxDBMapperTest {
       this.val = val;
     }
   }
-
 }

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -76,7 +76,7 @@ public class InfluxDBMapperTest {
     );
   }
 
-  /*
+
   @Test
   public void testInstantOnTime() {
     ServerMeasure serverMeasure = createMeasure();
@@ -86,7 +86,7 @@ public class InfluxDBMapperTest {
     ServerMeasure persistedMeasure = influxDBMapper.query(ServerMeasure.class).get(0);
     Assert.assertEquals(instant,persistedMeasure.getTime());
   }
-  */
+
 
   @AfterEach
   public void cleanUp() throws Exception {


### PR DESCRIPTION
Hi! I needed a save and load object only functionality thus I created some utils in order to persist and load measurement models directly.

Just like the [DynamoDBMapper](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.html) in java I believe it would be a great feature to add to influxdb.

To the measurement annotation I added information such as the retention policy and the database

I made a class that inherits the InfluxDBResultMapper. I think it can be the same in the first place.

I added the query measurement by the model and saving them by model 

What might be confusing is saving by providing the time. It can be instant only but this has to do with the result mapper parsing it to Instant. If no time column is provided it will use the system time.

Some examples follow

```java
@Measurement(name = "server_measure", database = UDP_DATABASE, retentionPolicy = "default")
static class ServerMeasure {

  /** Check the instant convertions */
  @Column(name = "time")
  private Instant time;

  @Column(name = "name", tag = true)
  private String name;

  @Column(name = "cpu")
  private double cpu;

  @Column(name = "healthy")
  private boolean healthy;

  @Column(name = "min")
  private long uptime;

  /** TODO bigdecimal unsupported? */
  @Column(name = "memory_utilization")
  private Double memoryUtilization;
```

Save it

```java
ServerMeasure serverMeasure = new ServerMeasure();
serverMeasure.setName("maverick");
serverMeasure.setCpu(4.3d);
serverMeasure.setHealthy(true);
serverMeasure.setUptime(1234l);
serverMeasure.setMemoryUtilization(new Double(34.5));
influxDBMapper.save(serverMeasure);

```

Load using the model

```java
List<ServerMeasure> persistedMeasure = influxDBMapper.query(ServerMeasure.class);
```

Load using the query

```java
Query query = ..create your query
List<ServerMeasure> persistedMeasure = influxDBMapper.query(query,ServerMeasure.class);
```

Kind Regards