### PR TITLE
Fix bug #398, unable to set inf retention duration

### DIFF
--- a/src/main/java/org/influxdb/impl/Preconditions.java
+++ b/src/main/java/org/influxdb/impl/Preconditions.java
@@ -54,7 +54,7 @@ public final class Preconditions {
    * @throws IllegalArgumentException if the given duration is not valid.
    */
   public static void checkDuration(final String duration, final String name) throws IllegalArgumentException {
-    if (!duration.matches("(\\d+[wdmhs])+")) {
+    if (!duration.matches("(\\d+[wdmhs])|inf+")) {
       throw new IllegalArgumentException("Invalid InfluxDB duration: " + duration
          + "for " + name);
     }

--- a/src/test/java/org/influxdb/impl/PreconditionsTest.java
+++ b/src/test/java/org/influxdb/impl/PreconditionsTest.java
@@ -52,4 +52,11 @@ public class PreconditionsTest {
 		});
   }
 
+  @Test
+  public void testCheckDurationInf(){
+    final String duration = "inf";
+    Assertions.assertDoesNotThrow(()->{
+      Preconditions.checkDuration(duration, "duration");
+    });
+  }
 }


### PR DESCRIPTION
This pull request fixes issue described by #398 .


The issues was caused by the preconditions not handling instances when the retention duration is set to inf (infinity).

The idea of the fix is to account or _**inf**_ being passed as a retention duration being including it in the regex check for valid durations.

This PR also contains change in unit tests: new test was added to ensure that a duration type of _**inf**_ does not cause an **_IllegalArgumentException_**.