### PR TITLE
Ignore .checkstyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test-output/
 .idea/
 *iml
 .m2/
+.checkstyle


### PR DESCRIPTION
The file `.checkstyle` is automatically created by Eclipse during checkstyle, and it should be ignored, since it unnecessarily considered a change for commit.