### PR TITLE
Close OkHttpClient when closing InfluxDBImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.15 [unreleased]
 
+### Fixes
+
+- Close underlying OkHttpClient when closing [Issue #359](https://github.com/influxdata/influxdb-java/issues/359)
+
 ### Features
 
 - Query and BatchPoints do not mandate a database name, in which case the InfluxDB database

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -85,6 +85,7 @@ public class InfluxDBImpl implements InfluxDB {
   private final String hostName;
   private String version;
   private final Retrofit retrofit;
+  private final OkHttpClient client;
   private final InfluxDBService influxDBService;
   private BatchProcessor batchProcessor;
   private final AtomicBoolean batchEnabled = new AtomicBoolean(false);
@@ -173,8 +174,9 @@ public class InfluxDBImpl implements InfluxDB {
       break;
     }
 
+    this.client = clonedOkHttpBuilder.build();
     Retrofit.Builder clonedRetrofitBuilder = retrofitBuilder.baseUrl(url).build().newBuilder();
-    this.retrofit = clonedRetrofitBuilder.client(clonedOkHttpBuilder.build())
+    this.retrofit = clonedRetrofitBuilder.client(this.client)
             .addConverterFactory(converterFactory).build();
     this.influxDBService = this.retrofit.create(InfluxDBService.class);
 
@@ -197,9 +199,10 @@ public class InfluxDBImpl implements InfluxDB {
 
     this.gzipRequestInterceptor = new GzipRequestInterceptor();
     OkHttpClient.Builder clonedBuilder = client.build().newBuilder();
+    this.client = clonedBuilder.addInterceptor(loggingInterceptor).addInterceptor(gzipRequestInterceptor).
+        addInterceptor(new BasicAuthInterceptor(username, password)).build();
     this.retrofit = new Retrofit.Builder().baseUrl(url)
-        .client(clonedBuilder.addInterceptor(loggingInterceptor).addInterceptor(gzipRequestInterceptor).
-            addInterceptor(new BasicAuthInterceptor(username, password)).build())
+        .client(this.client)
         .addConverterFactory(MoshiConverterFactory.create()).build();
     this.influxDBService = influxDBService;
 
@@ -825,6 +828,8 @@ public class InfluxDBImpl implements InfluxDB {
    */
   @Override
   public void close() {
+    this.client.dispatcher().executorService().shutdown();
+    this.client.connectionPool().evictAll();
     try {
         this.disableBatch();
     } finally {

--- a/src/test/java/org/influxdb/impl/InfluxDBImplTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBImplTest.java
@@ -1,0 +1,48 @@
+package org.influxdb.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import okhttp3.OkHttpClient;
+
+public class InfluxDBImplTest {
+
+  private InfluxDB influxDB;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    this.influxDB = TestUtils.connectToInfluxDB();
+  }
+  
+  @AfterEach
+  public void cleanup() {
+    influxDB.close();
+  }
+
+  @Test
+  public void closeOkHttpClient() throws Exception { 
+    OkHttpClient client = getPrivateField(influxDB, "client");
+    assertFalse(client.dispatcher().executorService().isShutdown());
+    assertFalse(client.connectionPool().connectionCount() == 0);
+    influxDB.close();
+    assertTrue(client.dispatcher().executorService().isShutdown());
+    assertTrue(client.connectionPool().connectionCount() == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  static <T> T getPrivateField(final Object obj, final String name)
+      throws Exception {
+    Field field = obj.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    return (T) field.get(obj);
+  }
+
+}


### PR DESCRIPTION
Fixes #359 and #286.

For the test, we can either expose the `client` as package protected for the test classes, or we use reflection by the Test method.

The test case uses the second mechanism.