### PR TITLE
pojo to timestamp field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.16
+
+### Fixes
+
+- Add new annotation called TimeColumn for timestamp field in POJO bean, this can set Point time and precision field correctly, also avoid UnableToParseException when flush Point to influx.
+
 ## 2.15 [2019-02-22]
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -231,11 +231,12 @@ public class Cpu {
 }
 ```
 
-2. Add @Measurement and @Column annotations:
+2. Add @Measurement,@TimeColumn and @Column annotations:
 
 ```Java
 @Measurement(name = "cpu")
 public class Cpu {
+    @TimeColumn
     @Column(name = "time")
     private Instant time;
     @Column(name = "host", tag = true)
@@ -270,7 +271,7 @@ Having the same POJO class Cpu
 ```java
 String dbName = "myTimeseries";
 String rpName = "aRetentionPolicy";
-// Cpu has annotations @Measurement and @Column
+// Cpu has annotations @Measurement,@TimeColumn and @Column
 Cpu cpu = new Cpu();
 // ... setting data
 

--- a/src/main/java/org/influxdb/annotation/TimeColumn.java
+++ b/src/main/java/org/influxdb/annotation/TimeColumn.java
@@ -1,0 +1,13 @@
+package org.influxdb.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TimeColumn {
+    TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
+}

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.influxdb.BuilderException;
 import org.influxdb.annotation.Column;
@@ -263,10 +264,11 @@ public class Point {
 
         TimeColumn tc = field.getAnnotation(TimeColumn.class);
         if (tc != null && Instant.class.isAssignableFrom(field.getType())) {
-          Instant instant = (Instant) fieldValue;
-          TimeUnit timeUint = tc.timeUnit();
-          this.time = TimeUnit.MILLISECONDS.convert(instant.toEpochMilli(), timeUint);
-          this.precision = timeUint;
+          Optional.ofNullable((Instant) fieldValue).ifPresent(instant -> {
+            TimeUnit timeUint = tc.timeUnit();
+            this.time = TimeUnit.MILLISECONDS.convert(instant.toEpochMilli(), timeUint);
+            this.precision = timeUint;
+          });
           return;
         }
 


### PR DESCRIPTION
i add a new annotation for timestamp so that we can set point time and precision attribute when use addFieldsFromPOJO method,and also can reslove UnableToParseException when use this method with a pojo class has field which type is Instant