### PR TITLE
Fix issue 599: Query with different time format does not work if database is not specified.

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -923,7 +923,10 @@ public class InfluxDBImpl implements InfluxDB {
 
   private String getDatabase(final Query query) {
   	String db = query.getDatabase();
-  	return db == null ? this.database : db;
+  	if (db == null) {
+  		return this.database;
+	}
+  	return db;
   }
 
   private interface ChunkProccesor {

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -924,7 +924,7 @@ public class InfluxDBImpl implements InfluxDB {
   private String getDatabase(final Query query) {
   	String db = query.getDatabase();
   	if (db == null) {
-  		return this.database;
+  	    return this.database;
 	}
   	return db;
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBImpl.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBImpl.java
@@ -922,11 +922,11 @@ public class InfluxDBImpl implements InfluxDB {
   }
 
   private String getDatabase(final Query query) {
-  	String db = query.getDatabase();
-  	if (db == null) {
-  	    return this.database;
-	}
-  	return db;
+    String db = query.getDatabase();
+    if (db == null) {
+      return this.database;
+    }
+    return db;
   }
 
   private interface ChunkProccesor {

--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -60,7 +60,7 @@ public enum TimeUtil {
     case MICROSECONDS:
       return "u";
     case NANOSECONDS:
-      return "n";
+      return "ns";
     default:
       throw new IllegalArgumentException("time precision must be one of:" + ALLOWED_TIMEUNITS);
     }

--- a/src/main/java/org/influxdb/impl/TimeUtil.java
+++ b/src/main/java/org/influxdb/impl/TimeUtil.java
@@ -60,7 +60,7 @@ public enum TimeUtil {
     case MICROSECONDS:
       return "u";
     case NANOSECONDS:
-      return "ns";
+      return "n";
     default:
       throw new IllegalArgumentException("time precision must be one of:" + ALLOWED_TIMEUNITS);
     }

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -40,7 +40,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
-import org.junit.runner.notification.RunListener;
 
 /**
  * Test the InfluxDB API.


### PR DESCRIPTION
Fix for issue #599 - to use database information present in the client if not set in query.

I also changed TimeUtils#toTimePrecision to be in compliance with documentation. 