### PR TITLE
Fix #614: drop NaN and infinity values from fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Add new annotation called TimeColumn for timestamp field in POJO bean, this can set Point time and precision field correctly, also avoid UnableToParseException when flush Point to influx.
+- Skip fields with NaN and infinity values when writing to InfluxDB
+  [Issue #614](https://github.com/influxdata/influxdb-java/issues/614)
 
 ## 2.15 [2019-02-22]
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -483,6 +483,44 @@ public class PointTest {
       assertThat(tags).isEqualTo(correctOrder);
     }
 
+    @Test
+    public void lineProtocolSkippingOfNanFields() {
+		String lineProtocol;
+
+		lineProtocol = Point
+				.measurement("test")
+				.time(1, TimeUnit.MILLISECONDS)
+				.addField("float-valid", 1f)
+				.addField("float-nan", Float.NaN)
+				.addField("float-inf1", Float.NEGATIVE_INFINITY)
+				.addField("float-inf2", Float.POSITIVE_INFINITY)
+				.tag("host", "serverA")
+				.build()
+				.lineProtocol(TimeUnit.MILLISECONDS);
+		assertThat(lineProtocol).isEqualTo("test,host=serverA float-valid=1.0 1");
+
+		lineProtocol = Point
+				.measurement("test")
+				.time(1, TimeUnit.MILLISECONDS)
+				.addField("double-valid", 1d)
+				.addField("double-nan", Double.NaN)
+				.addField("double-inf1", Double.NEGATIVE_INFINITY)
+				.addField("double-inf2", Double.POSITIVE_INFINITY)
+				.tag("host", "serverA")
+				.build()
+				.lineProtocol(TimeUnit.MILLISECONDS);
+		assertThat(lineProtocol).isEqualTo("test,host=serverA double-valid=1.0 1");
+
+		lineProtocol = Point
+				.measurement("test")
+				.time(1, TimeUnit.MILLISECONDS)
+				.addField("double-nan", Double.NaN)
+				.tag("host", "serverA")
+				.build()
+				.lineProtocol(TimeUnit.MILLISECONDS);
+		assertThat(lineProtocol).isEqualTo("");
+    }
+
 
   @Test
   public void testAddFieldsFromPOJONullCheck() {


### PR DESCRIPTION
Fox for #614 - drop NaN and +/- infinity values from fields while serializing Point to line protocol. They are unsupported by InfluxDB and all issues relating to them are old and got no progress.

I went with the simplest solution, assuming that if these values will be supported in the future then probably a change in driver will be required, unless InfluxDB aligns exactly with current Java serialization (NaN to U+FFFD - invalid character, and infinity to `∞`).