### PR TITLE
Overriding Accept-Encoding header when gzip is disabled

### DIFF
--- a/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
+++ b/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
@@ -39,7 +39,9 @@ final class GzipRequestInterceptor implements Interceptor {
     @Override
     public Response intercept(final Interceptor.Chain chain) throws IOException {
         if (!enabled.get()) {
-            return chain.proceed(chain.request());
+            Request request = chain.request();
+            request = request.newBuilder().addHeader("Accept-Encoding", "identity").build();
+            return chain.proceed(request);
         }
 
         Request originalRequest = chain.request();


### PR DESCRIPTION
 - When gzip is disabled, do not add Accept-Encoding header to request. (Overrided with identity for Accept-Encoding)
 - In specific environments/deployments the addition of this encoding type causes issues