### PR TITLE
Excluding conflicting transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,11 +252,23 @@
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>retrofit</artifactId>
       <version>2.6.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okhttp3</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.squareup.retrofit2</groupId>
       <artifactId>converter-moshi</artifactId>
       <version>2.6.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.squareup.okio</groupId>
+          <artifactId>okio</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
     <groupId>org.msgpack</groupId>


### PR DESCRIPTION
influxdb-java has conflicting transitive dependencies, which causes issues when added as a dependency to a gradle project with a resolution strategy that prohibits version conflicts; e.g. `configurations.all { resolutionStrategy { failOnVersionConflict() } }`.
This PR attempts to solve that issue.