### PR TITLE
Allow only non null values to flow to influxDB

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -276,11 +276,11 @@ public class Point {
         }
 
         if (column.tag()) {
-          if(fieldValue != null) {
+          if (fieldValue != null) {
             this.tags.put(fieldName, (String) fieldValue);
           }
         } else {
-          if(fieldValue != null) {
+          if (fieldValue != null) {
             this.fields.put(fieldName, fieldValue);
           }
         }

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -276,9 +276,13 @@ public class Point {
         }
 
         if (column.tag()) {
-          this.tags.put(fieldName, (String) fieldValue);
+          if(fieldValue != null) {
+            this.tags.put(fieldName, (String) fieldValue);
+          }
         } else {
-          this.fields.put(fieldName, fieldValue);
+          if(fieldValue != null) {
+            this.fields.put(fieldName, fieldValue);
+          }
         }
 
       } catch (IllegalArgumentException | IllegalAccessException e) {


### PR DESCRIPTION
InfluxDB does not allow null values for tags or fields. When null is propagated to influx, it throws an exception and the data is lost. To avoid this populate the Builder with only non null values.