### PR TITLE
fix: consistency between addField from POJO and regular addField

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -178,6 +178,21 @@ public class Point {
       return this;
     }
 
+    public Builder addField(final String field, final int value) {
+      fields.put(field, value);
+      return this;
+    }
+
+    public Builder addField(final String field, final float value) {
+      fields.put(field, value);
+      return this;
+    }
+
+    public Builder addField(final String field, final short value) {
+      fields.put(field, value);
+      return this;
+    }
+
     public Builder addField(final String field, final Number value) {
       fields.put(field, value);
       return this;


### PR DESCRIPTION
Closes #653 

This PR fix inconsistency between coercing primitive numeric types by https://github.com/influxdata/influxdb-java/blob/37b93e9f5d20461142b186ceac4e4aa89503550c/src/main/java/org/influxdb/dto/Point.java#L235

and by https://github.com/influxdata/influxdb-java/blob/37b93e9f5d20461142b186ceac4e4aa89503550c/src/main/java/org/influxdb/dto/Point.java#L181.

The previous version of `public Builder addField(..., ...)` coerce `int` and `short` to `long` and `float` to `double`.