### PR TITLE
Allow to use BigInteger and BigDecimal for timestamps

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -235,6 +235,18 @@ public class Point {
     }
 
     /**
+     * Add a time to this point as Long.
+     * only kept for binary compatibility with previous releases.
+     *
+     * @param timeToSet      the time for this point as Long
+     * @param precisionToSet the TimeUnit
+     * @return the Builder instance.
+     */
+    public Builder time(final Long timeToSet, final TimeUnit precisionToSet) {
+      return time((Number) timeToSet, precisionToSet);
+    }
+
+    /**
      * Does this builder contain any fields?
      *
      * @return true, if the builder contains any fields, false otherwise.

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -398,7 +398,7 @@ public class PointTest {
         // WHEN i call lineProtocol(TimeUnit.SECONDS)
         String secondTime = p.lineProtocol(TimeUnit.SECONDS).replace("measurement foo=\"bar\" ", "");
 
-        // THEN the timestamp is in nanoseconds
+        // THEN the timestamp is the seconds part of the Instant
         assertThat(secondTime).isEqualTo(Long.toString(instant.getEpochSecond()));
     }
 
@@ -446,7 +446,7 @@ public class PointTest {
         // WHEN i call lineProtocol(TimeUnit.SECONDS)
         String secondTime = p.lineProtocol(TimeUnit.SECONDS).replace("measurement foo=\"bar\" ", "");
 
-        // THEN the timestamp is the integer part of the BigDecimal
+        // THEN the timestamp is the seconds part of the Instant
         assertThat(secondTime).isEqualTo(Long.toString(instant.getEpochSecond()));
     }
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -384,6 +384,30 @@ public class PointTest {
      * @throws Exception
      */
     @Test
+    public void testLineProtocolBigIntegerSeconds() throws Exception {
+        // GIVEN a point with nanosecond precision farther in the future than a long can hold
+        Instant instant = Instant.EPOCH.plus(600L * 365, ChronoUnit.DAYS);
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(BigInteger.valueOf(instant.getEpochSecond())
+                                .multiply(BigInteger.valueOf(1000000000L))
+                                .add(BigInteger.valueOf(instant.getNano())), TimeUnit.NANOSECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.SECONDS)
+        String secondTime = p.lineProtocol(TimeUnit.SECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is in nanoseconds
+        assertThat(secondTime).isEqualTo(Long.toString(instant.getEpochSecond()));
+    }
+
+    /**
+     * Tests for #267
+     *
+     * @throws Exception
+     */
+    @Test
     public void testLineProtocolBigDecimal() throws Exception {
         // GIVEN a point with nanosecond precision farther in the future than a long can hold
         Instant instant = Instant.EPOCH.plus(600L * 365, ChronoUnit.DAYS);
@@ -400,6 +424,30 @@ public class PointTest {
 
         // THEN the timestamp is the integer part of the BigDecimal
         assertThat(nanosTime).isEqualTo("18921600000000000001");
+    }
+
+    /**
+     * Tests for #267
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLineProtocolBigDecimalSeconds() throws Exception {
+        // GIVEN a point with nanosecond precision farther in the future than a long can hold
+        Instant instant = Instant.EPOCH.plus(600L * 365, ChronoUnit.DAYS);
+        Point p = Point
+                .measurement("measurement")
+                .addField("foo", "bar")
+                .time(BigDecimal.valueOf(instant.getEpochSecond())
+                                .multiply(BigDecimal.valueOf(1000000000L))
+                                .add(BigDecimal.valueOf(instant.getNano())).add(BigDecimal.valueOf(1.9123456)), TimeUnit.NANOSECONDS)
+                .build();
+
+        // WHEN i call lineProtocol(TimeUnit.SECONDS)
+        String secondTime = p.lineProtocol(TimeUnit.SECONDS).replace("measurement foo=\"bar\" ", "");
+
+        // THEN the timestamp is the integer part of the BigDecimal
+        assertThat(secondTime).isEqualTo(Long.toString(instant.getEpochSecond()));
     }
 
     /**


### PR DESCRIPTION
Allow to use BigInteger and BigDecimal for timestamps in the Point class to allow arbitrary timestamps with nanosecond precision.

Fixes #267

Won't break any existing code because it is still possible to use Long as timestamp.