### PR TITLE
fix bug: mapping from msgpack response to int, Integer, long, Long types works fine

### DIFF
--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -361,11 +361,11 @@ public class InfluxDBResultMapper {
       return true;
     }
     if (long.class.isAssignableFrom(fieldType)) {
-      field.setLong(object, ((Double) value).longValue());
+      field.setLong(object, ((Number) value).longValue());
       return true;
     }
     if (int.class.isAssignableFrom(fieldType)) {
-      field.setInt(object, ((Double) value).intValue());
+      field.setInt(object, ((Number) value).intValue());
       return true;
     }
     if (boolean.class.isAssignableFrom(fieldType)) {
@@ -382,11 +382,11 @@ public class InfluxDBResultMapper {
       return true;
     }
     if (Long.class.isAssignableFrom(fieldType)) {
-      field.set(object, Long.valueOf(((Double) value).longValue()));
+      field.set(object, ((Number) value).longValue());
       return true;
     }
     if (Integer.class.isAssignableFrom(fieldType)) {
-      field.set(object, Integer.valueOf(((Double) value).intValue()));
+      field.set(object, ((Number) value).intValue());
       return true;
     }
     if (Boolean.class.isAssignableFrom(fieldType)) {


### PR DESCRIPTION
All of the unit tests of the `InfluxDBResultMapper` is based on the assumption that all numbers in response from influxd is `Double`. It will be ok with `JSON`. But `msgpack` format is more precise.

So, `InfluxDBResultMapper` have errors. For example, it throws an exception when mapping number to `int`, `Integer`, `long`, `Long` types from `msgpack` responses, but works with `json`.

This PR fix it (with unit test).