### PR TITLE
Added version of query method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Added signature to InfluxDBMapper.query() with params final Query query, final Class<T> clazz, final String measurementName to leverage InfluxDBResultMapper.toPojo method with identical signature.
+- Added new signature to InfluxDBMapper.query() with params final Query query, final Class<T> clazz, final String measurementName to leverage InfluxDBResultMapper.toPojo method with identical signature.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2.20 [unreleased]
 
+### Features
+
+- Added signature to InfluxDBMapper.query() with params final Query query, final Class<T> clazz, final String measurementName to leverage InfluxDBResultMapper.toPojo method with identical signature.
+
+### Improvements
+
+- Test: Added test for new InfluxDBMapper.query() signature, as well as test for existing InfluxDBMapper.query(Class clazz) signature (previously only InfluxDBMapper.query(Query query, Class clazz) was tested).
+
 ## 2.19 [2020-05-18]
 
 ## 2.18 [2020-04-17]

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -21,7 +21,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     this.influxDB = influxDB;
   }
   
-    public <T> List<T> query(final Query query, final Class<T> clazz, String measurementName) {
+    public <T> List<T> query(final Query query, final Class<T> clazz, final String measurementName) {
     QueryResult queryResult = influxDB.query(query);
     return toPOJO(queryResult, clazz, measurementName);
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -21,7 +21,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
     this.influxDB = influxDB;
   }
   
-    public <T> List<T> query(final Query query, final Class<T> clazz, final String measurementName) {
+  public <T> List<T> query(final Query query, final Class<T> clazz, final String measurementName) {
     QueryResult queryResult = influxDB.query(query);
     return toPOJO(queryResult, clazz, measurementName);
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -20,6 +20,11 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
   public InfluxDBMapper(final InfluxDB influxDB) {
     this.influxDB = influxDB;
   }
+  
+    public <T> List<T> query(final Query query, final Class<T> clazz, String measurementName) {
+    QueryResult queryResult = influxDB.query(query);
+    return toPOJO(queryResult, clazz, measurementName);
+  }
 
   public <T> List<T> query(final Query query, final Class<T> clazz) {
     throwExceptionIfMissingAnnotation(clazz);

--- a/src/main/java/org/influxdb/impl/InfluxDBMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBMapper.java
@@ -20,7 +20,7 @@ public class InfluxDBMapper extends InfluxDBResultMapper {
   public InfluxDBMapper(final InfluxDB influxDB) {
     this.influxDB = influxDB;
   }
-  
+
   public <T> List<T> query(final Query query, final Class<T> clazz, final String measurementName) {
     QueryResult queryResult = influxDB.query(query);
     return toPOJO(queryResult, clazz, measurementName);

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -56,6 +56,24 @@ public class InfluxDBMapperTest {
   }
 
   @Test
+  public void testQueryWhenCalledWithClassOnly() {
+    ServerMeasure serverMeasure = createMeasure();
+    influxDBMapper.save(serverMeasure);
+
+    List<ServerMeasure> persistedMeasures = influxDBMapper.query(ServerMeasure.class);
+    Assert.assertTrue(persistedMeasures.size()>0);
+  }
+
+  @Test
+  public void testQueryWhenCalledWithQuery_Class_MeasurementName() {
+    ServerMeasure serverMeasure = createMeasure();
+    influxDBMapper.save(serverMeasure);
+
+    List<NonAnnotatedServerMeasure> persistedMeasures = influxDBMapper.query(new Query("SELECT * FROM server_measure",UDP_DATABASE), NonAnnotatedServerMeasure.class, "server_measure");
+    Assert.assertTrue(persistedMeasures.size()>0);
+  }
+
+  @Test
   public void testIllegalField() {
     InvalidMeasure invalidMeasure = new InvalidMeasure();
     invalidMeasure.setVal(new BigDecimal("2.3"));
@@ -105,6 +123,87 @@ public class InfluxDBMapperTest {
 
   @Measurement(name = "server_measure", database = UDP_DATABASE)
   static class ServerMeasure {
+
+    /** Check the instant conversions */
+    @Column(name = "time")
+    private Instant time;
+
+    @Column(name = "name", tag = true)
+    private String name;
+
+    @Column(name = "cpu")
+    private double cpu;
+
+    @Column(name = "healthy")
+    private boolean healthy;
+
+    @Column(name = "min")
+    private long uptime;
+
+    @Column(name = "memory_utilization")
+    private Double memoryUtilization;
+
+    @Column(name = "ip")
+    private String ip;
+
+    public Instant getTime() {
+      return time;
+    }
+
+    public void setTime(Instant time) {
+      this.time = time;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public double getCpu() {
+      return cpu;
+    }
+
+    public void setCpu(double cpu) {
+      this.cpu = cpu;
+    }
+
+    public boolean isHealthy() {
+      return healthy;
+    }
+
+    public void setHealthy(boolean healthy) {
+      this.healthy = healthy;
+    }
+
+    public long getUptime() {
+      return uptime;
+    }
+
+    public void setUptime(long uptime) {
+      this.uptime = uptime;
+    }
+
+    public Double getMemoryUtilization() {
+      return memoryUtilization;
+    }
+
+    public void setMemoryUtilization(Double memoryUtilization) {
+      this.memoryUtilization = memoryUtilization;
+    }
+
+    public String getIp() {
+      return ip;
+    }
+
+    public void setIp(String ip) {
+      this.ip = ip;
+    }
+  }
+
+  static class NonAnnotatedServerMeasure {
 
     /** Check the instant conversions */
     @Column(name = "time")


### PR DESCRIPTION
InfluxDBResultMapper was recently updated with this version of .toPojo:
  public <T> List<T> toPOJO(final QueryResult queryResult, final Class<T> clazz, final String measurementName)
      throws InfluxDBMapperException {
    return toPOJO(queryResult, clazz, measurementName, TimeUnit.MILLISECONDS);
  }

Adding  InfluxDBMapper.query(final Query query, final Class<T> clazz, String measurementName) to take advantage of the new toPojo variation to map a db with variable measurement names to a POJO. Without this pull, mapping Query to Pojo without @Measurement annotation requires both an InfluxDB instance to fetch the query result and an influxDBMapper instance to map to call toPojo directly.