### PR TITLE
#684: add tag checking for invalid characters

### DIFF
--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -52,6 +52,16 @@ public class InfluxDBException extends RuntimeException {
   static final String USER_NOT_AUTHORIZED_ERROR = "user is not authorized to write to database";
   static final String AUTHORIZATION_FAILED_ERROR = "authorization failed";
   static final String USERNAME_REQUIRED_ERROR = "username required";
+  static final String TAGGING_INVALID_ERROR = "tag name or value failed regex check";
+  
+  public static final class TaggingInvalidException extends InfluxDBException{
+    private TaggingInvalidException(final String message){
+      super(message);
+    }
+    public boolean isRetryWorth() {
+      return false;
+    }
+  }
 
   public static final class DatabaseNotFoundException extends InfluxDBException {
     private DatabaseNotFoundException(final String message) {
@@ -152,6 +162,8 @@ public class InfluxDBException extends RuntimeException {
     if (errorMessage.contains(CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR)) {
       return new CacheMaxMemorySizeExceededException(errorMessage);
     }
+    if (errorMessage.contains(TAGGING_INVALID_ERROR))
+      return new TaggingInvalidException(errorMessage);
     if (errorMessage.contains(USER_REQUIRED_ERROR)
             || errorMessage.contains(USER_NOT_AUTHORIZED_ERROR)
             || errorMessage.contains(AUTHORIZATION_FAILED_ERROR)

--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -53,7 +53,7 @@ public class InfluxDBException extends RuntimeException {
   static final String AUTHORIZATION_FAILED_ERROR = "authorization failed";
   static final String USERNAME_REQUIRED_ERROR = "username required";
   static final String TAGGING_INVALID_ERROR = "tag name or value failed regex check";
-  
+
   public static final class TaggingInvalidException extends InfluxDBException {
     private TaggingInvalidException(final String message) {
       super(message);

--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -54,8 +54,8 @@ public class InfluxDBException extends RuntimeException {
   static final String USERNAME_REQUIRED_ERROR = "username required";
   static final String TAGGING_INVALID_ERROR = "tag name or value failed regex check";
   
-  public static final class TaggingInvalidException extends InfluxDBException{
-    private TaggingInvalidException(final String message){
+  public static final class TaggingInvalidException extends InfluxDBException {
+    private TaggingInvalidException(final String message) {
       super(message);
     }
     public boolean isRetryWorth() {
@@ -162,8 +162,9 @@ public class InfluxDBException extends RuntimeException {
     if (errorMessage.contains(CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR)) {
       return new CacheMaxMemorySizeExceededException(errorMessage);
     }
-    if (errorMessage.contains(TAGGING_INVALID_ERROR))
+    if (errorMessage.contains(TAGGING_INVALID_ERROR)) {
       return new TaggingInvalidException(errorMessage);
+      }
     if (errorMessage.contains(USER_REQUIRED_ERROR)
             || errorMessage.contains(USER_NOT_AUTHORIZED_ERROR)
             || errorMessage.contains(AUTHORIZATION_FAILED_ERROR)

--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -53,15 +53,6 @@ public class InfluxDBException extends RuntimeException {
   static final String AUTHORIZATION_FAILED_ERROR = "authorization failed";
   static final String USERNAME_REQUIRED_ERROR = "username required";
 
-  public static final class TaggingInvalidException extends InfluxDBException {
-    private TaggingInvalidException(final String message) {
-      super(message);
-    }
-    public boolean isRetryWorth() {
-      return false;
-    }
-  }
-
   public static final class DatabaseNotFoundException extends InfluxDBException {
     private DatabaseNotFoundException(final String message) {
       super(message);

--- a/src/main/java/org/influxdb/InfluxDBException.java
+++ b/src/main/java/org/influxdb/InfluxDBException.java
@@ -52,7 +52,6 @@ public class InfluxDBException extends RuntimeException {
   static final String USER_NOT_AUTHORIZED_ERROR = "user is not authorized to write to database";
   static final String AUTHORIZATION_FAILED_ERROR = "authorization failed";
   static final String USERNAME_REQUIRED_ERROR = "username required";
-  static final String TAGGING_INVALID_ERROR = "tag name or value failed regex check";
 
   public static final class TaggingInvalidException extends InfluxDBException {
     private TaggingInvalidException(final String message) {
@@ -162,9 +161,6 @@ public class InfluxDBException extends RuntimeException {
     if (errorMessage.contains(CACHE_MAX_MEMORY_SIZE_EXCEEDED_ERROR)) {
       return new CacheMaxMemorySizeExceededException(errorMessage);
     }
-    if (errorMessage.contains(TAGGING_INVALID_ERROR)) {
-      return new TaggingInvalidException(errorMessage);
-      }
     if (errorMessage.contains(USER_REQUIRED_ERROR)
             || errorMessage.contains(USER_NOT_AUTHORIZED_ERROR)
             || errorMessage.contains(AUTHORIZATION_FAILED_ERROR)

--- a/src/main/java/org/influxdb/dto/BatchPoints.java
+++ b/src/main/java/org/influxdb/dto/BatchPoints.java
@@ -10,6 +10,10 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdb.InfluxDB.ConsistencyLevel;
+import org.influxdb.InfluxDBException;
+import org.influxdb.dto.utils.CheckTags;
+
+import static org.influxdb.dto.utils.CheckTags.*;
 
 /**
  * {Purpose of This Type}.
@@ -29,6 +33,7 @@ public class BatchPoints {
 
   BatchPoints() {
     // Only visible in the Builder
+    
   }
 
   /**
@@ -90,7 +95,16 @@ public class BatchPoints {
      * @return the Builder instance.
      */
     public Builder tag(final String tagName, final String value) {
+      Objects.requireNonNull(tagName, "tagName");
+      Objects.requireNonNull(value, "value");
+      if (!tagName.isEmpty()
+          && !value.isEmpty()
+          && CheckTags.isTagNameLegal(tagName)
+          && CheckTags.isTagValueLegal(value))
       this.tags.put(tagName, value);
+      else {
+      throw InfluxDBException.buildExceptionForErrorState("tag name or value failed regex check");
+      }
       return this;
     }
 

--- a/src/main/java/org/influxdb/dto/BatchPoints.java
+++ b/src/main/java/org/influxdb/dto/BatchPoints.java
@@ -93,10 +93,7 @@ public class BatchPoints {
     public Builder tag(final String tagName, final String value) {
       Objects.requireNonNull(tagName, "tagName");
       Objects.requireNonNull(value, "value");
-      if (!tagName.isEmpty()
-          && !value.isEmpty()
-          && CheckTags.isTagNameLegal(tagName)
-          && CheckTags.isTagValueLegal(value)) {
+      if (CheckTags.isLegalFullCheck(tagName, value)) {
         this.tags.put(tagName, value);
       }
       return this;

--- a/src/main/java/org/influxdb/dto/BatchPoints.java
+++ b/src/main/java/org/influxdb/dto/BatchPoints.java
@@ -102,9 +102,6 @@ public class BatchPoints {
           && CheckTags.isTagNameLegal(tagName)
           && CheckTags.isTagValueLegal(value))
       this.tags.put(tagName, value);
-      else {
-      throw InfluxDBException.buildExceptionForErrorState("tag name or value failed regex check");
-      }
       return this;
     }
 

--- a/src/main/java/org/influxdb/dto/BatchPoints.java
+++ b/src/main/java/org/influxdb/dto/BatchPoints.java
@@ -10,10 +10,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import org.influxdb.InfluxDB.ConsistencyLevel;
-import org.influxdb.InfluxDBException;
 import org.influxdb.dto.utils.CheckTags;
-
-import static org.influxdb.dto.utils.CheckTags.*;
 
 /**
  * {Purpose of This Type}.
@@ -33,7 +30,6 @@ public class BatchPoints {
 
   BatchPoints() {
     // Only visible in the Builder
-    
   }
 
   /**
@@ -100,8 +96,9 @@ public class BatchPoints {
       if (!tagName.isEmpty()
           && !value.isEmpty()
           && CheckTags.isTagNameLegal(tagName)
-          && CheckTags.isTagValueLegal(value))
-      this.tags.put(tagName, value);
+          && CheckTags.isTagValueLegal(value)) {
+        this.tags.put(tagName, value);
+      }
       return this;
     }
 

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -15,7 +15,6 @@ import java.util.TreeMap;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.influxdb.BuilderException;
-import org.influxdb.InfluxDBException;
 import org.influxdb.annotation.Column;
 import org.influxdb.annotation.Measurement;
 import org.influxdb.annotation.TimeColumn;
@@ -136,11 +135,9 @@ public class Point {
      */
     public Builder tag(final Map<String, String> tagsToAdd) {
       for (Entry<String, String> tag : tagsToAdd.entrySet()) {
-        if(CheckTags.isTagNameLegal(tag.getKey())
-        && CheckTags.isTagValueLegal(tag.getValue()))
-        tag(tag.getKey(), tag.getValue());
-        else
-          continue;
+        if (CheckTags.isTagNameLegal(tag.getKey()) && CheckTags.isTagValueLegal(tag.getValue())) {
+          tag(tag.getKey(), tag.getValue());
+        }
       }
       return this;
     }

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -124,9 +124,6 @@ public class Point {
           && CheckTags.isTagValueLegal(value)) {
         tags.put(tagName, value);
       }
-      else {
-        throw InfluxDBException.buildExceptionForErrorState("tag name or value failed regex check");
-      }
       return this;
     }
 
@@ -139,7 +136,11 @@ public class Point {
      */
     public Builder tag(final Map<String, String> tagsToAdd) {
       for (Entry<String, String> tag : tagsToAdd.entrySet()) {
+        if(CheckTags.isTagNameLegal(tag.getKey())
+        && CheckTags.isTagValueLegal(tag.getValue()))
         tag(tag.getKey(), tag.getValue());
+        else
+          continue;
       }
       return this;
     }

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -15,9 +15,11 @@ import java.util.TreeMap;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.influxdb.BuilderException;
+import org.influxdb.InfluxDBException;
 import org.influxdb.annotation.Column;
 import org.influxdb.annotation.Measurement;
 import org.influxdb.annotation.TimeColumn;
+import org.influxdb.dto.utils.CheckTags;
 import org.influxdb.impl.Preconditions;
 
 /**
@@ -116,8 +118,14 @@ public class Point {
     public Builder tag(final String tagName, final String value) {
       Objects.requireNonNull(tagName, "tagName");
       Objects.requireNonNull(value, "value");
-      if (!tagName.isEmpty() && !value.isEmpty()) {
+      if (!tagName.isEmpty()
+          && !value.isEmpty()
+          && CheckTags.isTagNameLegal(tagName)
+          && CheckTags.isTagValueLegal(value)) {
         tags.put(tagName, value);
+      }
+      else {
+        throw InfluxDBException.buildExceptionForErrorState("tag name or value failed regex check");
       }
       return this;
     }

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -117,10 +117,7 @@ public class Point {
     public Builder tag(final String tagName, final String value) {
       Objects.requireNonNull(tagName, "tagName");
       Objects.requireNonNull(value, "value");
-      if (!tagName.isEmpty()
-          && !value.isEmpty()
-          && CheckTags.isTagNameLegal(tagName)
-          && CheckTags.isTagValueLegal(value)) {
+      if (CheckTags.isLegalFullCheck(tagName, value)) {
         tags.put(tagName, value);
       }
       return this;
@@ -135,10 +132,7 @@ public class Point {
      */
     public Builder tag(final Map<String, String> tagsToAdd) {
       for (Entry<String, String> tag : tagsToAdd.entrySet()) {
-        if (!tag.getKey().isEmpty()
-            && !tag.getValue().isEmpty()
-            && CheckTags.isTagNameLegal(tag.getKey())
-            && CheckTags.isTagValueLegal(tag.getValue())) {
+        if (CheckTags.isLegalFullCheck(tag.getKey(), tag.getValue())) {
           tags.put(tag.getKey(), tag.getValue());
         }
       }

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -135,8 +135,11 @@ public class Point {
      */
     public Builder tag(final Map<String, String> tagsToAdd) {
       for (Entry<String, String> tag : tagsToAdd.entrySet()) {
-        if (CheckTags.isTagNameLegal(tag.getKey()) && CheckTags.isTagValueLegal(tag.getValue())) {
-          tag(tag.getKey(), tag.getValue());
+        if (!tag.getKey().isEmpty()
+            && !tag.getValue().isEmpty()
+            && CheckTags.isTagNameLegal(tag.getKey())
+            && CheckTags.isTagValueLegal(tag.getValue())) {
+          tags.put(tag.getKey(), tag.getValue());
         }
       }
       return this;

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
  *
  * {Other Notes Relating to This Type (Optional)}
  *
- * @author BrentonPoke
+ * @author Brenton Poke
  *
  */
 public final class CheckTags {

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -16,6 +16,8 @@ public final class CheckTags {
   static final String VALUEREGEX = "[\\x00-\\x7F]+";
   static final Pattern NAMEPATTERN = Pattern.compile(NAMEREGEX, Pattern.MULTILINE);
   static final Pattern VALUEPATTERN = Pattern.compile(VALUEREGEX, Pattern.MULTILINE);
+
+  private CheckTags() { }
   /**
    * Check a single tag's name according to the corresponding regular expression.
    *
@@ -28,7 +30,6 @@ public final class CheckTags {
     final Matcher matcher = NAMEPATTERN.matcher(name);
     return matcher.matches();
   }
-  
   /**
    * Check a single tag's name according to the corresponding regular expression.
    *

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  */
 public final class CheckTags {
   static final String nameRegex = "([a-zA-Z0-9-_]+)";
-  static final String valueRegex = "[[:ascii:]]+";
+  static final String valueRegex = "[\\x00-\\x7F]+";
   static final Pattern namePattern = Pattern.compile(nameRegex, Pattern.MULTILINE);
   static final Pattern valuePattern = Pattern.compile(valueRegex, Pattern.MULTILINE);
   
@@ -28,7 +28,7 @@ public final class CheckTags {
   
   public static Boolean isTagNameLegal(String name){
     final Matcher matcher = namePattern.matcher(name);
-    return matcher.groupCount() == 1 && matcher.matches();
+    return matcher.matches();
   }
   
   /**

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -1,0 +1,47 @@
+package org.influxdb.dto.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * {Purpose of This Type}.
+ *
+ * {Other Notes Relating to This Type (Optional)}
+ *
+ * @author BrentonPoke
+ *
+ */
+public final class CheckTags {
+  static final String nameRegex = "([a-zA-Z0-9-_]+)";
+  static final String valueRegex = "[[:ascii:]]+";
+  static final Pattern namePattern = Pattern.compile(nameRegex, Pattern.MULTILINE);
+  static final Pattern valuePattern = Pattern.compile(valueRegex, Pattern.MULTILINE);
+  
+  /**
+   * Check a single tag's name according to the corresponding regular expression.
+   *
+   * @param name
+   *            the tag name
+   * @return Boolean indicating that the tag name is legal
+   *
+   */
+  
+  public static Boolean isTagNameLegal(String name){
+    final Matcher matcher = namePattern.matcher(name);
+    return matcher.groupCount() == 1 && matcher.matches();
+  }
+  
+  /**
+   * Check a single tag's name according to the corresponding regular expression.
+   *
+   * @param value
+   *            the tag value
+   * @return Boolean indicating that the tag value is legal
+   *
+   */
+  public static Boolean isTagValueLegal(String value){
+    final Matcher matcher = valuePattern.matcher(value);
+    return matcher.matches();
+  }
+  
+}

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -4,7 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * {Purpose of This Type}.
+ * Utility class intended for internal use. Checks the format of tag names and values to see if they conform to a regular expression.
  *
  * {Other Notes Relating to This Type (Optional)}
  *
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
  *
  */
 public final class CheckTags {
-  static final String NAMEREGEX = "([a-zA-Z0-9-_]+)";
+  static final String NAMEREGEX = "([^\\\\n\\\\r]+)";
   static final String VALUEREGEX = "[\\x00-\\x7F]+";
   static final Pattern NAMEPATTERN = Pattern.compile(NAMEREGEX, Pattern.MULTILINE);
   static final Pattern VALUEPATTERN = Pattern.compile(VALUEREGEX, Pattern.MULTILINE);

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -12,11 +12,10 @@ import java.util.regex.Pattern;
  *
  */
 public final class CheckTags {
-  static final String nameRegex = "([a-zA-Z0-9-_]+)";
-  static final String valueRegex = "[\\x00-\\x7F]+";
-  static final Pattern namePattern = Pattern.compile(nameRegex, Pattern.MULTILINE);
-  static final Pattern valuePattern = Pattern.compile(valueRegex, Pattern.MULTILINE);
-  
+  static final String NAMEREGEX = "([a-zA-Z0-9-_]+)";
+  static final String VALUEREGEX = "[\\x00-\\x7F]+";
+  static final Pattern NAMEPATTERN = Pattern.compile(NAMEREGEX, Pattern.MULTILINE);
+  static final Pattern VALUEPATTERN = Pattern.compile(VALUEREGEX, Pattern.MULTILINE);
   /**
    * Check a single tag's name according to the corresponding regular expression.
    *
@@ -25,9 +24,8 @@ public final class CheckTags {
    * @return Boolean indicating that the tag name is legal
    *
    */
-  
-  public static Boolean isTagNameLegal(String name){
-    final Matcher matcher = namePattern.matcher(name);
+  public static Boolean isTagNameLegal(final String name) {
+    final Matcher matcher = NAMEPATTERN.matcher(name);
     return matcher.matches();
   }
   
@@ -39,9 +37,8 @@ public final class CheckTags {
    * @return Boolean indicating that the tag value is legal
    *
    */
-  public static Boolean isTagValueLegal(String value){
-    final Matcher matcher = valuePattern.matcher(value);
+  public static Boolean isTagValueLegal(final String value) {
+    final Matcher matcher = VALUEPATTERN.matcher(value);
     return matcher.matches();
   }
-  
 }

--- a/src/main/java/org/influxdb/dto/utils/CheckTags.java
+++ b/src/main/java/org/influxdb/dto/utils/CheckTags.java
@@ -4,17 +4,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Utility class intended for internal use. Checks the format of tag names and values to see if they conform to a regular expression.
- *
- * {Other Notes Relating to This Type (Optional)}
+ * Utility class intended for internal use.
+ * Checks the format of tag names and values to see if they conform to a regular expression.
  *
  * @author Brenton Poke
  *
  */
 public final class CheckTags {
-  static final String NAMEREGEX = "([^\\\\n\\\\r]+)";
+  static final String NAMEREGEX = "[^\r\n]+";
   static final String VALUEREGEX = "[\\x00-\\x7F]+";
-  static final Pattern NAMEPATTERN = Pattern.compile(NAMEREGEX, Pattern.MULTILINE);
+  static final Pattern NAMEPATTERN = Pattern.compile(NAMEREGEX);
   static final Pattern VALUEPATTERN = Pattern.compile(VALUEREGEX, Pattern.MULTILINE);
 
   private CheckTags() { }
@@ -41,5 +40,11 @@ public final class CheckTags {
   public static Boolean isTagValueLegal(final String value) {
     final Matcher matcher = VALUEPATTERN.matcher(value);
     return matcher.matches();
+  }
+  public static Boolean isLegalFullCheck(final String name, final String value) {
+    return !name.isEmpty()
+        && !value.isEmpty()
+        && CheckTags.isTagNameLegal(name)
+        && CheckTags.isTagValueLegal(value);
   }
 }

--- a/src/test/java/org/influxdb/dto/CheckTagsTest.java
+++ b/src/test/java/org/influxdb/dto/CheckTagsTest.java
@@ -1,0 +1,54 @@
+package org.influxdb.dto;
+
+import org.influxdb.dto.utils.CheckTags;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+public class CheckTagsTest {
+  @Test
+  public void TagNameNewLineTest() {
+    final String tagname = "mad\ndrid";
+    final String tagname1 = "maddrid\n";
+    final String tagname2 = "\nmaddrid";
+    Assert.assertFalse(CheckTags.isTagNameLegal(tagname));
+    Assert.assertFalse(CheckTags.isTagNameLegal(tagname1));
+    Assert.assertFalse(CheckTags.isTagNameLegal(tagname2));
+  }
+  @Test
+  public void TagNameSymbolTest() {
+    final String tagname = "$cost";
+    final String tagname1 = "!cost";
+    Assert.assertFalse(CheckTags.isTagNameLegal(tagname));
+    Assert.assertFalse(CheckTags.isTagNameLegal(tagname1));
+  }
+  @Test
+  public void TagNameHyphenTest() {
+    final String tagname = "-cost";
+    final String tagname1 = "bushel-cost";
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname));
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname1));
+  }
+  @Test
+  public void TagNameUnderscoreTest() {
+    final String tagname = "_cost_";
+    final String tagname1 = "bushel_cost";
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname));
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname1));
+  }
+  @Test
+  public void TagValueASCIITest() {
+    final String tagvalue = "$15";
+    final String tagvalue1 = "$34,000";
+    final String tagvalue2 = "65%";
+    final String tagvalue3 = "startrek@cbs.com";
+    final String tagvalue4 = "%SYSTEM_VARARG%";
+    Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue));
+    Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue1));
+    Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue2));
+    Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue3));
+    Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue4));
+  }
+}

--- a/src/test/java/org/influxdb/dto/CheckTagsTest.java
+++ b/src/test/java/org/influxdb/dto/CheckTagsTest.java
@@ -1,5 +1,7 @@
 package org.influxdb.dto;
 
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
 import org.influxdb.dto.utils.CheckTags;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -13,6 +15,10 @@ public class CheckTagsTest {
     final String tagname = "mad\ndrid";
     final String tagname1 = "maddrid\n";
     final String tagname2 = "\nmaddrid";
+    
+    Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag(tagname,"city").addField("a", 1.0).build();
+    Assert.assertFalse(point.getTags().containsKey("madrid"));
+    Assert.assertFalse(point.getTags().containsKey("mad\nrid"));
     Assert.assertFalse(CheckTags.isTagNameLegal(tagname));
     Assert.assertFalse(CheckTags.isTagNameLegal(tagname1));
     Assert.assertFalse(CheckTags.isTagNameLegal(tagname2));
@@ -21,13 +27,19 @@ public class CheckTagsTest {
   public void TagNameSymbolTest() {
     final String tagname = "$cost";
     final String tagname1 = "!cost";
-    Assert.assertFalse(CheckTags.isTagNameLegal(tagname));
-    Assert.assertFalse(CheckTags.isTagNameLegal(tagname1));
+    Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag(tagname,"$15").addField("a", 1.0).build();
+    Assert.assertFalse(point.getTags().containsKey("cost"));
+    Assert.assertTrue(point.getTags().containsKey("$cost"));
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname));
+    Assert.assertTrue(CheckTags.isTagNameLegal(tagname1));
   }
   @Test
   public void TagNameHyphenTest() {
     final String tagname = "-cost";
     final String tagname1 = "bushel-cost";
+    Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag(tagname,"$15").addField("a", 1.0).build();
+    Assert.assertTrue(point.getTags().containsKey("-cost"));
+    Assert.assertFalse(point.getTags().containsKey("cost"));
     Assert.assertTrue(CheckTags.isTagNameLegal(tagname));
     Assert.assertTrue(CheckTags.isTagNameLegal(tagname1));
   }
@@ -35,6 +47,8 @@ public class CheckTagsTest {
   public void TagNameUnderscoreTest() {
     final String tagname = "_cost_";
     final String tagname1 = "bushel_cost";
+    Point point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag(tagname,"$15").addField("a", 1.0).build();
+    Assert.assertTrue(point.getTags().containsKey("_cost_"));
     Assert.assertTrue(CheckTags.isTagNameLegal(tagname));
     Assert.assertTrue(CheckTags.isTagNameLegal(tagname1));
   }
@@ -45,10 +59,32 @@ public class CheckTagsTest {
     final String tagvalue2 = "65%";
     final String tagvalue3 = "startrek@cbs.com";
     final String tagvalue4 = "%SYSTEM_VARARG%";
+    Point.Builder point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("cost",tagvalue).addField("a", 1.0);
+    Assertions.assertThat(point.build().lineProtocol()).isEqualTo("test,cost=$15 a=1.0 1");
     Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue));
     Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue1));
     Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue2));
     Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue3));
     Assert.assertTrue(CheckTags.isTagValueLegal(tagvalue4));
+    Assert.assertFalse(CheckTags.isTagValueLegal("ąćę"));
+    
+  }
+  @Test
+  public void TagsNullOrEmpty(){
+    final String tagname = null;
+    final String tagvalue = null;
+    final String tagvalue1 = "";
+    
+    Assert.assertThrows(NullPointerException.class, ()-> {
+      Point.Builder point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("cost",tagvalue).addField("a", 1.0);
+    });
+  
+    Assert.assertThrows(NullPointerException.class, ()-> {
+      Point.Builder point = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag(tagname,"whistle while you work").addField("a", 1.0);
+    });
+    
+    Point.Builder point1 = Point.measurement("test").time(1, TimeUnit.NANOSECONDS).tag("cost",tagvalue1).addField("a", 1.0);
+    Assert.assertTrue(point1.build().getTags().isEmpty());
+  
   }
 }


### PR DESCRIPTION
This is to address a concern brought up in #684 where strings like "mad\nrid" with a \n character would bork a tag. I approached this through a set of two regular expressions:
`nameRegex = "([a-zA-Z0-9-_]+)"`
`valueRegex = "[\x00-\x7F]+"`

Names of tags I interpret as being more strict than values, which should probably be allowed the full range of ASCII characters. Current unknowns are weird preferences others might want to report in values. I personally think ASCII codes 0-127 should be sufficient for everybody's needs, but comment below.

These are applied through a utils subpackage created in the dto package. It's not intended to be used by the developer, but I wanted something slightly portable that can be used in dto classes in the future. <strike>I also added a new exception to the `InfluxDBException` wrapper so the modified tag methods in the `Point` and `BatchPoints` classes can through it to the developer to let them know what's wrong.</strike> There is a new exception, but to pass the unit tests, I've removed the throws for them.

I am new to this codebase, but am familiar with timeseries databases. Hope this is a good starting point.