### PR TITLE
Request for annotation for null values on pojo fields of type String.

### DIFF
--- a/src/main/java/org/influxdb/annotation/Default.java
+++ b/src/main/java/org/influxdb/annotation/Default.java
@@ -9,4 +9,9 @@ import java.lang.annotation.Target;
 @Target(value = ElementType.FIELD)
 public @interface Default {
   String value() default "";
+  long longValue() default 0L;
+  int intValue() default 0;
+  double doubleValue() default 0.0d;
+  float floatValue() default 0.0f;
+  boolean boolValue() default false;
 }

--- a/src/main/java/org/influxdb/annotation/Default.java
+++ b/src/main/java/org/influxdb/annotation/Default.java
@@ -1,0 +1,12 @@
+package org.influxdb.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = ElementType.FIELD)
+public @interface Default {
+  String value() default "";
+}

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.influxdb.BuilderException;
 import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Default;
 import org.influxdb.annotation.Measurement;
 import org.influxdb.annotation.TimeColumn;
 import org.influxdb.impl.Preconditions;
@@ -274,7 +275,6 @@ public class Point {
           if (column == null) {
             continue;
           }
-
           field.setAccessible(true);
           String fieldName = column.name();
           addFieldByAttribute(pojo, field, column, fieldName);
@@ -322,6 +322,10 @@ public class Point {
             this.fields.put(fieldName, fieldValue);
           }
         }
+          if(field.isAnnotationPresent(Default.class)) {
+            Default val = field.getAnnotation(Default.class);
+            field.set(pojo,val.value());
+          }
 
       } catch (IllegalArgumentException | IllegalAccessException e) {
         // Can not happen since we use metadata got from the object

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -293,7 +293,8 @@ public class Point {
     private void addFieldByAttribute(final Object pojo, final Field field, final Column column,
         final String fieldName) {
       try {
-        if (field.isAnnotationPresent(Default.class)) {
+        
+        if (field.isAnnotationPresent(Default.class) && field.get(pojo) == null) {
           Default val = field.getAnnotation(Default.class);
           if (field.getType().equals(String.class)) {
             field.set(pojo, val.value());

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -322,9 +322,9 @@ public class Point {
             this.fields.put(fieldName, fieldValue);
           }
         }
-          if(field.isAnnotationPresent(Default.class)) {
+          if (field.isAnnotationPresent(Default.class)) {
             Default val = field.getAnnotation(Default.class);
-            field.set(pojo,val.value());
+            field.set(pojo, val.value());
           }
 
       } catch (IllegalArgumentException | IllegalAccessException e) {

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -293,6 +293,26 @@ public class Point {
     private void addFieldByAttribute(final Object pojo, final Field field, final Column column,
         final String fieldName) {
       try {
+        if (field.isAnnotationPresent(Default.class)) {
+          Default val = field.getAnnotation(Default.class);
+          if (field.getType().equals(String.class)) {
+            field.set(pojo, val.value());
+          } else if (field.getType().equals(Long.class)) {
+            field.set(pojo, val.longValue());
+          } else if (field.getType().equals(Integer.class)) {
+            field.set(pojo, val.intValue());
+          } else if (field.getType().equals(BigDecimal.class)) {
+            field.set(pojo, BigDecimal.valueOf(0L));
+          } else if (field.getType().equals(BigInteger.class)) {
+            field.set(pojo, BigInteger.valueOf(0));
+          } else if (field.getType().equals(Boolean.class)) {
+            field.set(pojo, val.boolValue());
+          } else if (field.getType().equals(Float.class)) {
+            field.set(pojo, val.floatValue());
+          } else if (field.getType().equals(Double.class)) {
+            field.set(pojo, val.doubleValue());
+          }
+        }
         Object fieldValue = field.get(pojo);
 
         TimeColumn tc = field.getAnnotation(TimeColumn.class);
@@ -322,10 +342,6 @@ public class Point {
             this.fields.put(fieldName, fieldValue);
           }
         }
-          if (field.isAnnotationPresent(Default.class)) {
-            Default val = field.getAnnotation(Default.class);
-            field.set(pojo, val.value());
-          }
 
       } catch (IllegalArgumentException | IllegalAccessException e) {
         // Can not happen since we use metadata got from the object

--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -293,7 +293,6 @@ public class Point {
     private void addFieldByAttribute(final Object pojo, final Field field, final Column column,
         final String fieldName) {
       try {
-        
         if (field.isAnnotationPresent(Default.class) && field.get(pojo) == null) {
           Default val = field.getAnnotation(Default.class);
           if (field.getType().equals(String.class)) {

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -797,11 +797,23 @@ public class PointTest {
     @Test
     public void testAddFieldsFromPOJOWithDefaultAnnotation() {
         PojoWithDefaultAnnotation pojo = new PojoWithDefaultAnnotation();
-        pojo.setAuthor("");
-        pojo.setId("1");
+
         Point p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
-        Assertions.assertEquals(pojo.getAuthor(),p.getFields().get("author"));
-        Assertions.assertEquals(pojo.getId(),p.getFields().get("id"));
+        Assertions.assertTrue(pojo.getISBN().equals(20L));
+        Assertions.assertTrue(pojo.booleanObject.equals(false));
+        Assertions.assertTrue(pojo.integerObject.equals(20));
+        Assertions.assertTrue(pojo.doubleObject.equals(20.0d));
+        Assertions.assertTrue(pojo.floatObject.equals(0.0f));
+        Assertions.assertTrue(pojo.bigDecimal.equals(BigDecimal.ZERO));
+        Assertions.assertTrue(pojo.bigInteger.equals(BigInteger.ZERO));
+    
+        Assertions.assertTrue(p.getFields().get("author").equals(""));
+        Assertions.assertTrue(p.getFields().get("id").equals("2"));
+        Assertions.assertTrue(p.getFields().get("booleanObject").equals(false));
+        Assertions.assertTrue(p.getFields().get("doubleObject").equals(20.0d));
+        Assertions.assertTrue(p.getFields().get("floatObject").equals(0.0f));
+        Assertions.assertTrue(p.getFields().get("bigDecimal").equals(BigDecimal.ZERO));
+        Assertions.assertTrue(p.getFields().get("bigInteger").equals(BigInteger.ZERO));
     }
 
     @Test
@@ -835,14 +847,65 @@ public class PointTest {
     @Measurement(name = "mymeasurement")
     static class PojoWithDefaultAnnotation {
         
-        @Default("1")
+        @Default("2")
         @Column(name = "id")
         private String id;
         //check alternate order of annotations.  ¯\_(ツ)_/¯
         @Column(name = "author")
         @Default
         private String author;
+    
+        @Default(doubleValue = 20.0d)
+        @Column(name = "doubleObject")
+        private Double doubleObject;
         
+        @Default(intValue = 20)
+        @Column(name = "integerObject")
+        private Integer integerObject;
+        
+        @Default
+        @Column(name = "booleanObject")
+        private Boolean booleanObject;
+        @Default
+        @Column(name = "floatObject")
+        private Float floatObject;
+        
+        @Default
+        @Column(name = "bigDecimal")
+        private BigDecimal bigDecimal;
+        
+        @Default
+        @Column(name = "bigInteger")
+        private BigInteger bigInteger;
+        
+        @Default(longValue = 20L)
+        @Column(name = "ISBN")
+        private Long ISBN;
+    
+        public Double getDoubleObject() {
+            return doubleObject;
+        }
+    
+        public Integer getIntegerObject() {
+            return integerObject;
+        }
+    
+        public Boolean getBooleanObject() {
+            return booleanObject;
+        }
+    
+        public Float getFloatObject() {
+            return floatObject;
+        }
+    
+        public BigDecimal getBigDecimal() {
+            return bigDecimal;
+        }
+    
+        public BigInteger getBigInteger() {
+            return bigInteger;
+        }
+    
         public String getAuthor() {
             return author;
         }
@@ -854,6 +917,12 @@ public class PointTest {
         }
         public void setId(String id) {
             this.id = id;
+        }
+        public Long getISBN() {
+            return ISBN;
+        }
+        public void setISBN(Long ISBN) {
+            this.ISBN = ISBN;
         }
     }
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -797,15 +797,11 @@ public class PointTest {
     @Test
     public void testAddFieldsFromPOJOWithDefaultAnnotation() {
         PojoWithDefaultAnnotation pojo = new PojoWithDefaultAnnotation();
-        PojoWithDefaultAnnotation pojo1 = new PojoWithDefaultAnnotation();
         pojo.setAuthor("");
         pojo.setId("1");
         Point p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
-        //Completely separate pojo with different reference to compare against
-        pojo1.setAuthor("");
-        pojo1.setId("1");
-        Assertions.assertEquals(pojo1.getAuthor(),p.getFields().get("author"));
-        Assertions.assertEquals(pojo1.getId(),p.getFields().get("id"));
+        Assertions.assertEquals(pojo.getAuthor(),p.getFields().get("author"));
+        Assertions.assertEquals(pojo.getId(),p.getFields().get("id"));
     }
 
     @Test

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -797,11 +797,15 @@ public class PointTest {
     @Test
     public void testAddFieldsFromPOJOWithDefaultAnnotation() {
         PojoWithDefaultAnnotation pojo = new PojoWithDefaultAnnotation();
+        PojoWithDefaultAnnotation pojo1 = new PojoWithDefaultAnnotation();
         pojo.setAuthor("");
         pojo.setId("1");
         Point p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
-        Assertions.assertEquals(pojo.getAuthor(),p.getFields().get("author"));
-        Assertions.assertEquals(pojo.getId(),p.getFields().get("id"));
+        //Completely separate pojo with different reference to compare against
+        pojo1.setAuthor("");
+        pojo1.setId("1");
+        Assertions.assertEquals(pojo1.getAuthor(),p.getFields().get("author"));
+        Assertions.assertEquals(pojo1.getId(),p.getFields().get("id"));
     }
 
     @Test

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -814,6 +814,29 @@ public class PointTest {
         Assertions.assertTrue(p.getFields().get("floatObject").equals(0.0f));
         Assertions.assertTrue(p.getFields().get("bigDecimal").equals(BigDecimal.ZERO));
         Assertions.assertTrue(p.getFields().get("bigInteger").equals(BigInteger.ZERO));
+    
+        //Soundness check
+        pojo.setId("41");
+        pojo.setAuthor("William Gibson");
+        pojo.setISBN(342134566545L);
+        pojo.setBigDecimal(BigDecimal.valueOf(12435125.435434));
+        pojo.setBooleanObject(true);
+        pojo.setBigInteger(new BigInteger(String.valueOf(54635265426256L)));
+        pojo.setDoubleObject(453.654d);
+        pojo.setFloatObject(5434.787f);
+        pojo.setIntegerObject(5346546);
+        p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
+        
+        Assertions.assertFalse(p.getFields().get("id").equals("2"));
+        Assertions.assertTrue(p.getFields().get("id").equals("41"));
+        Assertions.assertTrue(p.getFields().get("author").equals("William Gibson"));
+        Assertions.assertFalse(p.getFields().get("author").equals(""));
+        Assertions.assertFalse(p.getFields().get("booleanObject").equals(false));
+        Assertions.assertFalse(p.getFields().get("doubleObject").equals(20.0d));
+        Assertions.assertFalse(p.getFields().get("floatObject").equals(0.0f));
+        Assertions.assertFalse(p.getFields().get("bigDecimal").equals(BigDecimal.ZERO));
+        Assertions.assertFalse(p.getFields().get("bigInteger").equals(BigInteger.ZERO));
+        
     }
 
     @Test
@@ -904,6 +927,30 @@ public class PointTest {
     
         public BigInteger getBigInteger() {
             return bigInteger;
+        }
+    
+        public void setDoubleObject(Double doubleObject) {
+            this.doubleObject = doubleObject;
+        }
+    
+        public void setIntegerObject(Integer integerObject) {
+            this.integerObject = integerObject;
+        }
+    
+        public void setBooleanObject(Boolean booleanObject) {
+            this.booleanObject = booleanObject;
+        }
+    
+        public void setFloatObject(Float floatObject) {
+            this.floatObject = floatObject;
+        }
+    
+        public void setBigDecimal(BigDecimal bigDecimal) {
+            this.bigDecimal = bigDecimal;
+        }
+    
+        public void setBigInteger(BigInteger bigInteger) {
+            this.bigInteger = bigInteger;
         }
     
         public String getAuthor() {

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.influxdb.BuilderException;
 import org.influxdb.InfluxDB;
 import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Default;
 import org.influxdb.annotation.Measurement;
 import org.influxdb.annotation.TimeColumn;
 import org.influxdb.impl.InfluxDBImpl;
@@ -793,6 +794,15 @@ public class PointTest {
         Assertions.assertEquals(pojo.time, p.getFields().get("time"));
         Assertions.assertEquals(pojo.uuid, p.getTags().get("uuid"));
     }
+    @Test
+    public void testAddFieldsFromPOJOWithDefaultAnnotation() {
+        PojoWithDefaultAnnotation pojo = new PojoWithDefaultAnnotation();
+        pojo.setAuthor("");
+        pojo.setId("1");
+        Point p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
+        Assertions.assertEquals(pojo.getAuthor(),p.getFields().get("author"));
+        Assertions.assertEquals(pojo.getId(),p.getFields().get("id"));
+    }
 
     @Test
     public void testInheritMeasurement() {
@@ -818,6 +828,30 @@ public class PointTest {
             return id;
         }
 
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+    @Measurement(name = "mymeasurement")
+    static class PojoWithDefaultAnnotation {
+        
+        @Default("1")
+        @Column(name = "id")
+        private String id;
+        //check alternate order of annotations.  ¯\_(ツ)_/¯
+        @Column(name = "author")
+        @Default
+        private String author;
+        
+        public String getAuthor() {
+            return author;
+        }
+        public void setAuthor(String name) {
+            this.author = name;
+        }
+        public String getId() {
+            return id;
+        }
         public void setId(String id) {
             this.id = id;
         }


### PR DESCRIPTION
A `@Default` annotation was requested to protect pojos coming back with null strings in #661. I interpreted it to mean something along the lines of what's in the unit test. Would appreciate feedback.