### PR TITLE
feat: `POST` query variants serializes `'q'` parameter into HTTP body

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         jdk: [3-openjdk-16-slim, 3-jdk-14, 3-jdk-8-slim]
-        influxdb: [1.1, 1.6, 1.8]
+        influxdb: [1.1, 1.6, 1.8, 2.0]
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         jdk: [3-openjdk-16-slim, 3-jdk-14, 3-jdk-8-slim]
-        influxdb: [1.1, 1.6, 1.8]
+        influxdb: [1.1, 1.6, 1.8, 2.0]
 
     steps:
       - name: Checkout
@@ -27,3 +27,4 @@ jobs:
 
       - name: codecov
         run: bash <(curl -s https://codecov.io/bash)
+        if: matrix.influxdb != '2.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.22 [unreleased]
 
+### Improvements
+
+- Streaming query serializes `'q'` parameter into HTTP body [PR #765](https://github.com/influxdata/influxdb-java/pull/765)
+
 ## 2.21 [2020-12-04]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Streaming query serializes `'q'` parameter into HTTP body [PR #765](https://github.com/influxdata/influxdb-java/pull/765)
+- `POST` query variants serializes `'q'` parameter into HTTP body [PR #765](https://github.com/influxdata/influxdb-java/pull/765)
 
 ## 2.21 [2020-12-04]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is the official (and community-maintained) Java client library for [InfluxDB](https://www.influxdata.com/products/influxdb-overview/) (1.x), the open source time series database that is part of the TICK (Telegraf, InfluxDB, Chronograf, Kapacitor) stack.
 
-_Note: This library is for use with InfluxDB 1.x. For connecting to InfluxDB 2.x instances, please use the [influxdb-client-java](https://github.com/influxdata/influxdb-client-java) client._
+_Note: This library is for use with InfluxDB 1.x and [2.x compatibility API](https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/). For full supports of InfluxDB 2.x features, please use the [influxdb-client-java](https://github.com/influxdata/influxdb-client-java) client._
 
 ## Adding the library to your project
 

--- a/compile-and-test.sh
+++ b/compile-and-test.sh
@@ -20,6 +20,12 @@ docker run \
        --publish 8086:8086 \
        --publish 8089:8089/udp \
        --volume ${PWD}/influxdb.conf:/etc/influxdb/influxdb.conf \
+       --env DOCKER_INFLUXDB_INIT_MODE=setup \
+       --env DOCKER_INFLUXDB_INIT_USERNAME=my-user \
+       --env DOCKER_INFLUXDB_INIT_PASSWORD=my-password \
+       --env DOCKER_INFLUXDB_INIT_ORG=my-org \
+       --env DOCKER_INFLUXDB_INIT_BUCKET=my-bucket \
+       --env DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-token \
        influxdb:${INFLUXDB_VERSION}-alpine
 
 echo "Starting Nginx"
@@ -38,6 +44,20 @@ docker run \
 echo "Running tests"
 PROXY_API_URL=http://nginx:8080/influx-api/
 PROXY_UDP_PORT=8080
+if [[ "$INFLUXDB_VERSION" == "2.0" ]]
+then
+    TEST_EXPRESSION="InfluxDB2Test"
+    # Wait to start InfluxDB
+    docker run --link influxdb:influxdb ubuntu:20.04 bash -c "apt-get update \
+      && apt-get install wget --yes \
+      && wget -S --spider --tries=20 --retry-connrefused --waitretry=5 http://influxdb:8086/ping"
+    # Create DBRP Mapping
+    BUCKET_ID=$(docker exec influxdb bash -c "influx bucket list -o my-org -n my-bucket | grep my-bucket | xargs | cut -d ' ' -f 0")
+    docker exec influxdb bash -c "influx v1 dbrp create -o my-org --db mydb --rp autogen --default --bucket-id ${BUCKET_ID}"
+    docker exec influxdb bash -c "influx v1 auth create -o my-org --username my-user --password my-password --read-bucket ${BUCKET_ID} --write-bucket ${BUCKET_ID}"
+else
+    TEST_EXPRESSION="*"
+fi
 
 docker run --rm \
        --volume ${PWD}:/usr/src/mymaven \
@@ -49,7 +69,7 @@ docker run --rm \
        --env INFLUXDB_IP=influxdb \
        --env PROXY_API_URL=${PROXY_API_URL} \
        --env PROXY_UDP_PORT=${PROXY_UDP_PORT} \
-       maven:${MAVEN_JAVA_VERSION} mvn clean install
+       maven:${MAVEN_JAVA_VERSION} mvn clean install -Dtest="${TEST_EXPRESSION}"
 
 docker kill influxdb || true
 docker kill nginx || true

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -6,6 +6,8 @@ import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.Field;
+import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
@@ -48,8 +50,9 @@ interface InfluxDBService {
       @Query(EPOCH) String epoch, @Query(value = Q, encoded = true) String query);
 
   @POST("query")
+  @FormUrlEncoded
   public Call<QueryResult> query(@Query(DB) String db,
-          @Query(EPOCH) String epoch, @Query(value = Q, encoded = true) String query,
+          @Query(EPOCH) String epoch, @Field(value = Q, encoded = true) String query,
           @Query(value = PARAMS, encoded = true) String params);
 
   @GET("query")
@@ -57,18 +60,18 @@ interface InfluxDBService {
       @Query(value = Q, encoded = true) String query);
 
   @POST("query")
+  @FormUrlEncoded
   public Call<QueryResult> postQuery(@Query(DB) String db,
-      @Query(value = Q, encoded = true) String query);
+      @Field(value = Q, encoded = true) String query);
 
   @POST("query")
+  @FormUrlEncoded
   public Call<QueryResult> postQuery(@Query(DB) String db,
-          @Query(value = Q, encoded = true) String query, @Query(value = PARAMS, encoded = true) String params);
-
-  @GET("query")
-  public Call<QueryResult> query(@Query(value = Q, encoded = true) String query);
+          @Field(value = Q, encoded = true) String query, @Query(value = PARAMS, encoded = true) String params);
 
   @POST("query")
-  public Call<QueryResult> postQuery(@Query(value = Q, encoded = true) String query);
+  @FormUrlEncoded
+  public Call<QueryResult> postQuery(@Field(value = Q, encoded = true) String query);
 
   @Streaming
   @GET("query?chunked=true")
@@ -77,6 +80,7 @@ interface InfluxDBService {
 
   @Streaming
   @POST("query?chunked=true")
-  public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query,
+  @FormUrlEncoded
+  public Call<ResponseBody> query(@Query(DB) String db, @Field(value = Q, encoded = true) String query,
           @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
 }

--- a/src/test/java/org/influxdb/InfluxDB2Test.java
+++ b/src/test/java/org/influxdb/InfluxDB2Test.java
@@ -1,0 +1,57 @@
+package org.influxdb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.influxdb.dto.Query;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jakub Bednar (30/08/2021 11:31)
+ */
+@RunWith(JUnitPlatform.class)
+@EnabledIfEnvironmentVariable(named = "INFLUXDB_VERSION", matches = "2\\.0")
+public class InfluxDB2Test {
+
+    private InfluxDB influxDB;
+
+    @BeforeEach
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        String url = String.format("http://%s:%s", TestUtils.getInfluxIP(), TestUtils.getInfluxPORT(true));
+        influxDB = InfluxDBFactory
+                .connect(url, "my-user", "my-password")
+                .setDatabase("mydb")
+                .setRetentionPolicy("autogen");
+    }
+
+    @AfterEach
+    public void cleanup() {
+        influxDB.close();
+    }
+
+    @Test
+    public void testQuery() throws InterruptedException {
+
+        String measurement = TestUtils.getRandomMeasurement();
+
+        // prepare data
+        List<String> records = new ArrayList<>();
+        records.add(measurement + ",test=a value=1 1");
+        records.add(measurement + ",test=a value=2 2");
+        influxDB.write(records);
+
+        // query data
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        influxDB.query(new Query("SELECT * FROM " + measurement), 2, queryResult -> countDownLatch.countDown());
+
+        Assertions.assertTrue(countDownLatch.await(2, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
+++ b/src/test/java/org/influxdb/MessagePackInfluxDBTest.java
@@ -164,6 +164,18 @@ public class MessagePackInfluxDBTest extends InfluxDBTest {
     value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0).toString());
     Assertions.assertEquals(value, timeP3);
 
+    // WHEN I use the post query
+    queryResult = this.influxDB.query(new Query("SELECT * FROM " + measurement, dbName, true), TimeUnit.NANOSECONDS);
+
+    // THEN result will be same
+    Assertions.assertEquals(queryResult.getResults().get(0).getSeries().get(0).getValues().size(), 3);
+    value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(0).get(0).toString());
+    Assertions.assertEquals(value, timeP1);
+    value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(1).get(0).toString());
+    Assertions.assertEquals(value, timeP2);
+    value = Double.valueOf(queryResult.getResults().get(0).getSeries().get(0).getValues().get(2).get(0).toString());
+    Assertions.assertEquals(value, timeP3);
+
     this.influxDB.query(new Query("DROP DATABASE " + dbName));
   }
 

--- a/src/test/java/org/influxdb/impl/InfluxDBImplTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBImplTest.java
@@ -10,9 +10,12 @@ import org.influxdb.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
 import okhttp3.OkHttpClient;
 
+@RunWith(JUnitPlatform.class)
 public class InfluxDBImplTest {
 
   private InfluxDB influxDB;

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -16,7 +16,10 @@ import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
 
+@RunWith(JUnitPlatform.class)
 public class InfluxDBMapperTest {
 
   private InfluxDB influxDB;


### PR DESCRIPTION
## Proposed Changes

The `query` parameter for `post` variants of query is serialized into HTTP body.

It is usefull when you hit the `nginx` limit for `Request-URI` length, eq. HTTP error: `414 Request-URI Too Large`.

- https://docs.influxdata.com/influxdb/v1.3/guides/querying_data/#querying-data-using-the-http-api
- https://docs.influxdata.com/influxdb/cloud/reference/api/influxdb-1x/query/

Following query variants also respects the `requiresPost` settings:

1. `QueryResult query(Query, TimeUnit)`
1. `void query(Query, int, BiConsumer<Cancellable, QueryResult>,
                   Runnable, Consumer<Throwable>)`

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `compile-and-test.sh` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
