### PR TITLE
chore(ci): use new Codecov uploader for reporting code coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,8 +26,8 @@ jobs:
 
       - name: codecov
         run: |
-          apt-get update
-          apt-get install gpg libdigest-sha-perl -y
+          sudo apt-get update
+          sudo apt-get install gpg libdigest-sha-perl -y
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,17 @@ jobs:
         run: ./compile-and-test.sh
 
       - name: codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        run: |
+          apt-get update
+          apt-get install gpg libdigest-sha-perl -y
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x ./codecov
+          ./codecov
         if: matrix.influxdb != '2.0' && matrix.influxdb != '2.1'
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: codecov
         run: |
-          apt-get update
-          apt-get install gpg libdigest-sha-perl -y
+          sudo apt-get update
+          sudo apt-get install gpg libdigest-sha-perl -y
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
           curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,5 +29,15 @@ jobs:
         run: ./compile-and-test.sh
 
       - name: codecov
-        run: bash <(curl -s https://codecov.io/bash)
+        run: |
+          apt-get update
+          apt-get install gpg libdigest-sha-perl -y
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+          curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
+          chmod +x ./codecov
+          ./codecov
         if: matrix.influxdb != '2.0' && matrix.influxdb != '2.1'


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.