### PR TITLE
Revert "Bump checkstyle from 9.3 to 10.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.0</version>
+            <version>9.3</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
Reverts influxdata/influxdb-java#813 because jdk8 does not work anymore.

other idea would be to remove jdk8 from the CI matrix, but i think this is still a relevant jdk.