### PR TITLE
chore(release): add implementation information to Jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.2</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Proposed Changes

Add default implementation entries to Jar manifest. The manifest will contain these entries:

1. `Implementation-Title`: ${project.name}
1. `Implementation-Version`: ${project.version}
1. `Implementation-Vendor`: ${project.organization.name}

https://maven.apache.org/shared/maven-archiver/


It is useful when you want to retrieve the client version by `java` code:

```java
Package mainPackage = org.influxdb.InfluxDB.class.getPackage();
String version = mainPackage.getImplementationVersion();
```


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
