### PR TITLE
fix: use gzip compression only for /write endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 - Add implementation information to `Jar` manifest [PR #847](https://github.com/influxdata/influxdb-java/pull/847)
 
+### Fixes
+- Only the request to /write endpoint should be compressed by GZIP [PR #851](https://github.com/influxdata/influxdb-java/pull/851)
+
 ## 2.22 [2021-09-17]
 
 ### Improvements

--- a/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
+++ b/src/main/java/org/influxdb/impl/GzipRequestInterceptor.java
@@ -2,6 +2,7 @@ package org.influxdb.impl;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -18,6 +19,8 @@ import okio.Okio;
  * @author fujian1115 [at] gmail.com
  */
 final class GzipRequestInterceptor implements Interceptor {
+
+    private static final Pattern WRITE_PATTERN = Pattern.compile(".*/write", Pattern.CASE_INSENSITIVE);
 
     private AtomicBoolean enabled = new AtomicBoolean(false);
 
@@ -45,6 +48,10 @@ final class GzipRequestInterceptor implements Interceptor {
         Request originalRequest = chain.request();
         RequestBody body = originalRequest.body();
         if (body == null || originalRequest.header("Content-Encoding") != null) {
+            return chain.proceed(originalRequest);
+        }
+
+        if (!WRITE_PATTERN.matcher(originalRequest.url().encodedPath()).matches()) {
             return chain.proceed(originalRequest);
         }
 

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test the InfluxDB API.
  *
@@ -1460,8 +1462,13 @@ public class InfluxDBTest {
   @Test
   public void testQueryPostWithGZIPCompression() {
     this.influxDB.enableGzip();
-    String command = String.format("CREATE DATABASE db_gzip_%d", System.currentTimeMillis());
-    this.influxDB.query(new Query(command, null, true));
+    String database = "db_gzip_" + System.currentTimeMillis();
+    this.influxDB.query(new Query(String.format("CREATE DATABASE %s", database), null, true));
+    QueryResult query = this.influxDB.query(new Query("SHOW DATABASES", null, true));
+    assertThat(query.getResults()).hasSize(1);
+    assertThat(query.getResults().get(0).getSeries()).hasSize(1);
+    assertThat(query.getResults().get(0).getSeries().get(0).getValues()).contains(Collections.singletonList(database));
+    this.influxDB.query(new Query(String.format("DROP DATABASE %s", database), null, true));
   }
 
   private static final class MyInfluxDBBean {

--- a/src/test/java/org/influxdb/InfluxDBTest.java
+++ b/src/test/java/org/influxdb/InfluxDBTest.java
@@ -1457,6 +1457,13 @@ public class InfluxDBTest {
     Assertions.assertTrue(MyInfluxDBBean.OKHTTP_BUILDER.interceptors().isEmpty());
   }
 
+  @Test
+  public void testQueryPostWithGZIPCompression() {
+    this.influxDB.enableGzip();
+    String command = String.format("CREATE DATABASE db_gzip_%d", System.currentTimeMillis());
+    this.influxDB.query(new Query(command, null, true));
+  }
+
   private static final class MyInfluxDBBean {
 
     static final OkHttpClient.Builder OKHTTP_BUILDER = new OkHttpClient.Builder();


### PR DESCRIPTION
Closes #848

## Proposed Changes

Only the request to `/write` endpoint should be compressed by GZIP.

- https://github.com/influxdata/influxdb/blob/d01ea614650b8682e9f3097115333c380981ad93/services/httpd/handler.go#L1588
- https://github.com/influxdata/influxdb/blob/d01ea614650b8682e9f3097115333c380981ad93/services/httpd/handler.go#L571

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
