### PR TITLE
chore(ci): use InfluxDB 2.1, 2.2 and 2.3 in CI pipeline

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         jdk: [3-openjdk-17-slim, 3-jdk-14, 3-jdk-8-slim]
-        influxdb: ['1.1', '1.6', '1.8', '2.0', '2.1']
+        influxdb: ['1.1', '1.6', '1.8', '2.1', '2.2', '2.3']
 
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM
           chmod +x ./codecov
           ./codecov
-        if: matrix.influxdb != '2.0' && matrix.influxdb != '2.1'
+        if: matrix.influxdb != '2.1' && matrix.influxdb != '2.2' && matrix.influxdb != '2.3'
 
 
   # deploy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         jdk: [3-openjdk-17-slim, 3-jdk-14, 3-jdk-8-slim]
-        influxdb: ['1.1', '1.6', '1.8', '2.0', '2.1']
+        influxdb: ['1.1', '1.6', '1.8', '2.1', '2.2', '2.3']
 
     steps:
       - name: Checkout
@@ -40,4 +40,4 @@ jobs:
           shasum -a 256 -c codecov.SHA256SUM
           chmod +x ./codecov
           ./codecov
-        if: matrix.influxdb != '2.0' && matrix.influxdb != '2.1'
+        if: matrix.influxdb != '2.1' && matrix.influxdb != '2.2' && matrix.influxdb != '2.3'


### PR DESCRIPTION
## Proposed Changes

Add InfluxDB 2.1, 2.2 and 2.3 to CI pipeline.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `mvn test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
