### PR TITLE
Default column name to pojo field name, and add `allFields` mode to `Measurement` annotation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -323,21 +323,40 @@ public class Cpu {
 }
 ```
 
-2. Add @Measurement,@TimeColumn and @Column annotations:
+2. Add @Measurement,@TimeColumn and @Column annotations (column names default to field names unless otherwise specified):
 
 ```Java
 @Measurement(name = "cpu")
 public class Cpu {
     @TimeColumn
-    @Column(name = "time")
+    @Column
     private Instant time;
     @Column(name = "host", tag = true)
     private String hostname;
-    @Column(name = "region", tag = true)
+    @Column(tag = true)
     private String region;
-    @Column(name = "idle")
+    @Column
     private Double idle;
-    @Column(name = "happydevop")
+    @Column
+    private Boolean happydevop;
+    @Column(name = "uptimesecs")
+    private Long uptimeSecs;
+    // getters (and setters if you need)
+}
+```
+
+Alternatively, you can use:
+
+```Java
+@Measurement(name = "cpu", allFields = true)
+public class Cpu {
+    @TimeColumn
+    private Instant time;
+    @Column(name = "host", tag = true)
+    private String hostname;
+    @Column(tag = true)
+    private String region;
+    private Double idle;
     private Boolean happydevop;
     @Column(name = "uptimesecs")
     private Long uptimeSecs;

--- a/src/main/java/org/influxdb/annotation/Column.java
+++ b/src/main/java/org/influxdb/annotation/Column.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
 public @interface Column {
 
   /**
-   * If unset, the annotated field's name will be used as the column name
+   * If unset, the annotated field's name will be used as the column name.
    */
   String name() default "";
 

--- a/src/main/java/org/influxdb/annotation/Exclude.java
+++ b/src/main/java/org/influxdb/annotation/Exclude.java
@@ -26,16 +26,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author fmachado
+ * When a POJO annotated with {@code @Measurement(allFields = true)} is loaded or saved,
+ * this annotation can be used to exclude some of its fields.
+ * @see Measurement#allFields()
+ *
+ * @author Eran Leshem
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface Column {
-
-  /**
-   * If unset, the annotated field's name will be used as the column name
-   */
-  String name() default "";
-
-  boolean tag() default false;
+public @interface Exclude {
 }

--- a/src/main/java/org/influxdb/annotation/Measurement.java
+++ b/src/main/java/org/influxdb/annotation/Measurement.java
@@ -40,4 +40,11 @@ public @interface Measurement {
   String retentionPolicy() default "autogen";
 
   TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
+
+  /**
+   * If {@code true}, then all non-static fields of this measurement will be loaded or saved,
+   * regardless of any {@code @Column} annotations.
+   * @see Exclude
+   */
+  boolean allFields() default false;
 }

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -20,7 +20,14 @@
  */
 package org.influxdb.impl;
 
+import org.influxdb.InfluxDBMapperException;
+import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Exclude;
+import org.influxdb.annotation.Measurement;
+import org.influxdb.dto.QueryResult;
+
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -32,11 +39,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-
-import org.influxdb.InfluxDBMapperException;
-import org.influxdb.annotation.Column;
-import org.influxdb.annotation.Measurement;
-import org.influxdb.dto.QueryResult;
 
 /**
  * Main class responsible for mapping a QueryResult to a POJO.
@@ -213,18 +215,32 @@ public class InfluxDBResultMapper {
       }
       ConcurrentMap<String, Field> influxColumnAndFieldMap = new ConcurrentHashMap<>();
 
+      Measurement measurement = clazz.getAnnotation(Measurement.class);
+      boolean allFields = measurement != null && measurement.allFields();
+
       Class<?> c = clazz;
       while (c != null) {
         for (Field field : c.getDeclaredFields()) {
           Column colAnnotation = field.getAnnotation(Column.class);
-          if (colAnnotation != null) {
-            influxColumnAndFieldMap.put(colAnnotation.name(), field);
+          if (colAnnotation == null && !(allFields
+                  && !field.isAnnotationPresent(Exclude.class) && !Modifier.isStatic(field.getModifiers()))) {
+            continue;
           }
+
+          influxColumnAndFieldMap.put(getFieldName(field, colAnnotation), field);
         }
         c = c.getSuperclass();
       }
       CLASS_FIELD_CACHE.putIfAbsent(clazz.getName(), influxColumnAndFieldMap);
     }
+  }
+
+  private static String getFieldName(final Field field, final Column colAnnotation) {
+    if (colAnnotation != null && !colAnnotation.name().isEmpty()) {
+      return colAnnotation.name();
+    }
+
+    return field.getName();
   }
 
   String getMeasurementName(final Class<?> clazz) {
@@ -289,17 +305,11 @@ public class InfluxDBResultMapper {
 
   /**
    * InfluxDB client returns any number as Double.
-   * See https://github.com/influxdata/influxdb-java/issues/153#issuecomment-259681987
+   * See <a href="https://github.com/influxdata/influxdb-java/issues/153#issuecomment-259681987">...</a>
    * for more information.
    *
-   * @param object
-   * @param field
-   * @param value
-   * @param precision
-   * @throws IllegalArgumentException
-   * @throws IllegalAccessException
    */
-  <T> void setFieldValue(final T object, final Field field, final Object value, final TimeUnit precision)
+  private static <T> void setFieldValue(final T object, final Field field, final Object value, final TimeUnit precision)
     throws IllegalArgumentException, IllegalAccessException {
     if (value == null) {
       return;
@@ -325,8 +335,8 @@ public class InfluxDBResultMapper {
     }
   }
 
-  <T> boolean fieldValueModified(final Class<?> fieldType, final Field field, final T object, final Object value,
-                                 final TimeUnit precision)
+  static <T> boolean fieldValueModified(final Class<?> fieldType, final Field field, final T object, final Object value,
+                                        final TimeUnit precision)
     throws IllegalArgumentException, IllegalAccessException {
     if (String.class.isAssignableFrom(fieldType)) {
       field.set(object, String.valueOf(value));
@@ -351,8 +361,8 @@ public class InfluxDBResultMapper {
     return false;
   }
 
-  <T> boolean fieldValueForPrimitivesModified(final Class<?> fieldType, final Field field, final T object,
-    final Object value) throws IllegalArgumentException, IllegalAccessException {
+  static <T> boolean fieldValueForPrimitivesModified(final Class<?> fieldType, final Field field, final T object,
+                                                     final Object value) throws IllegalArgumentException, IllegalAccessException {
     if (double.class.isAssignableFrom(fieldType)) {
       field.setDouble(object, ((Double) value).doubleValue());
       return true;
@@ -372,8 +382,8 @@ public class InfluxDBResultMapper {
     return false;
   }
 
-  <T> boolean fieldValueForPrimitiveWrappersModified(final Class<?> fieldType, final Field field, final T object,
-    final Object value) throws IllegalArgumentException, IllegalAccessException {
+  static <T> boolean fieldValueForPrimitiveWrappersModified(final Class<?> fieldType, final Field field, final T object,
+                                                            final Object value) throws IllegalArgumentException, IllegalAccessException {
     if (Double.class.isAssignableFrom(fieldType)) {
       field.set(object, value);
       return true;
@@ -393,7 +403,7 @@ public class InfluxDBResultMapper {
     return false;
   }
 
-  private Long toMillis(final long value, final TimeUnit precision) {
+  private static Long toMillis(final long value, final TimeUnit precision) {
 
     return TimeUnit.MILLISECONDS.convert(value, precision);
   }

--- a/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBResultMapper.java
@@ -362,7 +362,8 @@ public class InfluxDBResultMapper {
   }
 
   static <T> boolean fieldValueForPrimitivesModified(final Class<?> fieldType, final Field field, final T object,
-                                                     final Object value) throws IllegalArgumentException, IllegalAccessException {
+                                                     final Object value)
+          throws IllegalArgumentException, IllegalAccessException {
     if (double.class.isAssignableFrom(fieldType)) {
       field.setDouble(object, ((Double) value).doubleValue());
       return true;
@@ -383,7 +384,8 @@ public class InfluxDBResultMapper {
   }
 
   static <T> boolean fieldValueForPrimitiveWrappersModified(final Class<?> fieldType, final Field field, final T object,
-                                                            final Object value) throws IllegalArgumentException, IllegalAccessException {
+                                                            final Object value)
+          throws IllegalArgumentException, IllegalAccessException {
     if (Double.class.isAssignableFrom(fieldType)) {
       field.set(object, value);
       return true;

--- a/src/test/java/org/influxdb/impl/InfluxDBResultMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBResultMapperTest.java
@@ -20,6 +20,17 @@
  */
 package org.influxdb.impl;
 
+import org.influxdb.InfluxDBMapperException;
+import org.influxdb.annotation.Column;
+import org.influxdb.annotation.Exclude;
+import org.influxdb.annotation.Measurement;
+import org.influxdb.annotation.TimeColumn;
+import org.influxdb.dto.QueryResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
@@ -30,16 +41,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import org.influxdb.InfluxDBMapperException;
-import org.influxdb.annotation.Column;
-import org.influxdb.annotation.Measurement;
-import org.influxdb.annotation.TimeColumn;
-import org.influxdb.dto.QueryResult;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
 /**
  * @author fmachado
@@ -71,6 +72,12 @@ public class InfluxDBResultMapperTest {
 
     // Then...
     Assertions.assertEquals(1, myList.size(), "there must be one entry in the result list");
+
+		//When...
+  	List<MyAllFieldsCustomMeasurement> myList1 = mapper.toPOJO(queryResult, MyAllFieldsCustomMeasurement.class);
+
+  	// Then...
+  	Assertions.assertEquals(1, myList1.size(), "there must be one entry in the result list");
   }
 
 	@Test
@@ -568,6 +575,35 @@ public class InfluxDBResultMapperTest {
 		private String nonColumn1;
 
 		@SuppressWarnings("unused")
+		private Random rnd;
+
+		@Override
+		public String toString() {
+			return "MyCustomMeasurement [time=" + time + ", uuid=" + uuid + ", doubleObject=" + doubleObject + ", longObject=" + longObject
+				+ ", integerObject=" + integerObject + ", doublePrimitive=" + doublePrimitive + ", longPrimitive=" + longPrimitive
+				+ ", integerPrimitive=" + integerPrimitive + ", booleanObject=" + booleanObject + ", booleanPrimitive=" + booleanPrimitive + "]";
+		}
+	}
+
+	@Measurement(name = "CustomMeasurement", allFields = true)
+	static class MyAllFieldsCustomMeasurement {
+		private Instant time;
+		private String uuid;
+		private Double doubleObject;
+		private Long longObject;
+		private Integer integerObject;
+		private double doublePrimitive;
+		private long longPrimitive;
+		private int integerPrimitive;
+		private Boolean booleanObject;
+		private boolean booleanPrimitive;
+
+		@SuppressWarnings("unused")
+		@Exclude
+		private String nonColumn1;
+
+		@SuppressWarnings("unused")
+		@Exclude
 		private Random rnd;
 
 		@Override


### PR DESCRIPTION
if `@Column` is used without a name, the annotated field's name is used as the column name.

In addition, when a pojo is annotated with `@Measurement(name = "...", allFields = true)`, then all its fields are loaded or saved.
Finally, an `@Exclude` annotation can be used for opting a field out in this mode.

Fixes #971.
