### PR TITLE
Fix time column with precision > ms

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -331,8 +331,7 @@ public class Point {
                                     .add(BigInteger.valueOf(instant.getNano()))
                                     .divide(BigInteger.valueOf(TimeUnit.NANOSECONDS.convert(1, timeUnit)));
             } else {
-              this.time = TimeUnit.MILLISECONDS.convert(instant.toEpochMilli(), timeUnit);
-              this.precision = timeUnit;
+              this.time = timeUnit.convert(instant.toEpochMilli(), TimeUnit.MILLISECONDS);
             }
             this.precision = timeUnit;
           });

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -696,6 +696,23 @@ public class PointTest {
     }
 
     @Test
+    public void testAddFieldsFromPOJOWithTimeColumnSeconds() throws NoSuchFieldException, IllegalAccessException {
+        TimeColumnPojoSec pojo = new TimeColumnPojoSec();
+        pojo.time = Instant.now().plusSeconds(132L).plus(365L * 12000, ChronoUnit.DAYS);
+        pojo.booleanPrimitive = true;
+
+        Point p = Point.measurementByPOJO(pojo.getClass()).addFieldsFromPOJO(pojo).build();
+        Field timeField = p.getClass().getDeclaredField("time");
+        Field precisionField = p.getClass().getDeclaredField("precision");
+        timeField.setAccessible(true);
+        precisionField.setAccessible(true);
+
+        Assertions.assertEquals(pojo.booleanPrimitive, p.getFields().get("booleanPrimitive"));
+        Assertions.assertEquals(TimeUnit.SECONDS, precisionField.get(p));
+        Assertions.assertEquals(pojo.time.getEpochSecond(), timeField.get(p));
+    }
+
+    @Test
     public void testAddFieldsFromPOJOWithTimeColumnNull() throws NoSuchFieldException, IllegalAccessException {
         TimeColumnPojo pojo = new TimeColumnPojo();
         pojo.booleanPrimitive = true;
@@ -912,6 +929,14 @@ public class PointTest {
         @TimeColumn(timeUnit = TimeUnit.NANOSECONDS)
         @Column(name = "time")
         private Instant time;
+    }
+
+    @Measurement(name = "tcmeasurement", allFields = true)
+    static class TimeColumnPojoSec {
+        boolean booleanPrimitive;
+
+        @TimeColumn(timeUnit = TimeUnit.SECONDS)
+        Instant time;
     }
 
     @Measurement(name = "mymeasurement")


### PR DESCRIPTION
When `@TimeColumn` is used with `timeUnit` larger than a millisecond, saving the pojo would result in a wrong timestamp.
This change fixes that.
