### PR TITLE
Unify `Point`'s and `InfluxDBMapper`'s POJO saving logic

### DIFF
--- a/src/main/java/org/influxdb/dto/Point.java
+++ b/src/main/java/org/influxdb/dto/Point.java
@@ -350,7 +350,7 @@ public class Point {
           }
         } else {
           if (fieldValue != null) {
-            this.fields.put(fieldName, fieldValue);
+            setField(field.getType(), fieldName, fieldValue);
           }
         }
 
@@ -378,6 +378,32 @@ public class Point {
       }
       point.setTags(this.tags);
       return point;
+    }
+
+    private void setField(
+            final Class<?> fieldType,
+            final String columnName,
+            final Object value) {
+      if (boolean.class.isAssignableFrom(fieldType) || Boolean.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (boolean) value);
+      } else if (long.class.isAssignableFrom(fieldType) || Long.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (long) value);
+      } else if (double.class.isAssignableFrom(fieldType) || Double.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (double) value);
+      } else if (float.class.isAssignableFrom(fieldType) || Float.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (float) value);
+      } else if (int.class.isAssignableFrom(fieldType) || Integer.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (int) value);
+      } else if (short.class.isAssignableFrom(fieldType) || Short.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (short) value);
+      } else if (String.class.isAssignableFrom(fieldType)) {
+        addField(columnName, (String) value);
+      } else if (Enum.class.isAssignableFrom(fieldType)) {
+        addField(columnName, ((Enum<?>) value).name());
+      } else {
+        throw new InfluxDBMapperException(
+                "Unsupported type " + fieldType + " for column " + columnName);
+      }
     }
   }
 

--- a/src/test/java/org/influxdb/dto/PointTest.java
+++ b/src/test/java/org/influxdb/dto/PointTest.java
@@ -737,7 +737,7 @@ public class PointTest {
     }
 
     @Test
-    public void testAddFieldsFromPOJOWithData() throws NoSuchFieldException, IllegalAccessException {
+    public void testAddFieldsFromPOJOWithData() {
         Pojo pojo = new Pojo();
         pojo.booleanObject = true;
         pojo.booleanPrimitive = false;
@@ -760,7 +760,6 @@ public class PointTest {
         Assertions.assertEquals(pojo.integerPrimitive, p.getFields().get("integerPrimitive"));
         Assertions.assertEquals(pojo.longObject, p.getFields().get("longObject"));
         Assertions.assertEquals(pojo.longPrimitive, p.getFields().get("longPrimitive"));
-        Assertions.assertEquals(pojo.time, p.getFields().get("time"));
         Assertions.assertEquals(pojo.uuid, p.getTags().get("uuid"));
     }
 
@@ -815,7 +814,6 @@ public class PointTest {
         Assertions.assertEquals(pojo.integerPrimitive, p.getFields().get("integerPrimitive"));
         Assertions.assertEquals(pojo.longObject, p.getFields().get("longObject"));
         Assertions.assertEquals(pojo.longPrimitive, p.getFields().get("longPrimitive"));
-        Assertions.assertEquals(pojo.time, p.getFields().get("time"));
         Assertions.assertEquals(pojo.uuid, p.getTags().get("uuid"));
     }
 
@@ -962,6 +960,7 @@ public class PointTest {
         private boolean booleanPrimitive;
 
         @Column(name = "time")
+        @TimeColumn
         private Instant time;
 
         @Column(name = "uuid", tag = true)
@@ -1078,6 +1077,7 @@ public class PointTest {
         public boolean booleanPrimitive;
 
         @Column(name = "time")
+        @TimeColumn
         public Instant time;
 
         @Column(name = "uuid", tag = true)

--- a/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
+++ b/src/test/java/org/influxdb/impl/InfluxDBMapperTest.java
@@ -11,6 +11,7 @@ import org.influxdb.InfluxDBMapperException;
 import org.influxdb.TestUtils;
 import org.influxdb.annotation.Column;
 import org.influxdb.annotation.Measurement;
+import org.influxdb.annotation.TimeColumn;
 import org.influxdb.dto.Query;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
@@ -129,6 +130,7 @@ public class InfluxDBMapperTest {
 
     /** Check the instant conversions */
     @Column(name = "time")
+    @TimeColumn
     private Instant time;
 
     @Column(name = "name", tag = true)
@@ -322,6 +324,7 @@ public class InfluxDBMapperTest {
   static class NonInstantTime {
 
     @Column(name = "time")
+    @TimeColumn
     private long time;
 
     public long getTime() {


### PR DESCRIPTION
Currently, there are two duplicate and somewhat divergent versions of this logic:
- `Point` doesn't check that values conform to field types and doesn't constrain allowed value types
- `InfluxDBMapper` uses a `time` field rather than `@TimeColumn`

This change unifies the logic and takes the stricter path, which means that it may break existing code that relies on the current lenient logic.
