### PR TITLE
chore/update-ubuntu

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Bumping ubuntu runner to `-latest` as 20.04 is EOL and will be disabled 1 Apr 25.