### PR TITLE
fix: migrate Maven OSS repository to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -163,7 +163,7 @@
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
           <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
         </configuration>


### PR DESCRIPTION
This PR migrate deployment from Sonatype OSS repository to Central Portal. For more info see: 
- https://central.sonatype.org/pages/ossrh-eol/
- https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/ 
