### PR TITLE
feat(query): add streaming query with a timeunit

### DIFF
--- a/src/main/java/org/influxdb/InfluxDB.java
+++ b/src/main/java/org/influxdb/InfluxDB.java
@@ -539,6 +539,25 @@ public interface InfluxDB extends AutoCloseable {
                     Consumer<Throwable> onFailure);
 
   /**
+   * Execute a streaming query against a database.
+   *
+   * @param query
+   *            the query to execute.
+   * @param timeUnit
+   *            the time unit of the results.
+   * @param chunkSize
+   *            the number of QueryResults to process in one chunk.
+   * @param onNext
+   *            the consumer to invoke for each received QueryResult; with capability to discontinue a streaming query
+   * @param onComplete
+   *            the onComplete to invoke for successfully end of stream
+   * @param onFailure
+   *            the consumer for error handling
+   */
+  public void query(Query query, TimeUnit timeUnit, int chunkSize, BiConsumer<Cancellable, QueryResult> onNext, Runnable onComplete,
+                    Consumer<Throwable> onFailure);
+
+  /**
    * Execute a query against a database.
    *
    * @param query

--- a/src/main/java/org/influxdb/impl/InfluxDBService.java
+++ b/src/main/java/org/influxdb/impl/InfluxDBService.java
@@ -78,7 +78,19 @@ interface InfluxDBService {
   @Streaming
   @POST("query?chunked=true")
   @FormUrlEncoded
+  public Call<ResponseBody> postQuery(@Query(DB) String db, @Field(value = Q, encoded = true) String query, @Query(EPOCH) String epoch,
+         @Query(CHUNK_SIZE) int chunkSize);
+
+  @Streaming
+  @POST("query?chunked=true")
+  @FormUrlEncoded
   public Call<ResponseBody> postQuery(@Query(DB) String db, @Field(value = Q, encoded = true) String query,
+         @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
+
+  @Streaming
+  @POST("query?chunked=true")
+  @FormUrlEncoded
+  public Call<ResponseBody> postQuery(@Query(DB) String db, @Field(value = Q, encoded = true) String query, @Query(EPOCH) String epoch,
          @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
 
   @POST("query")
@@ -92,6 +104,16 @@ interface InfluxDBService {
 
   @Streaming
   @GET("query?chunked=true")
+  public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query, @Query(EPOCH) String epoch,
+      @Query(CHUNK_SIZE) int chunkSize);
+
+  @Streaming
+  @GET("query?chunked=true")
   public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query,
+          @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
+
+  @Streaming
+  @GET("query?chunked=true")
+  public Call<ResponseBody> query(@Query(DB) String db, @Query(value = Q, encoded = true) String query, @Query(EPOCH) String epoch,
           @Query(CHUNK_SIZE) int chunkSize, @Query(value = PARAMS, encoded = true) String params);
 }


### PR DESCRIPTION
For performance reasons, I want to use the TimeUnit parameter so that I don't have to parse timestamps from String to Instant during result processing.
It was only available without asynchronous mode.

Its the same subject as #418 and #509